### PR TITLE
Step2 - 요금 조회

### DIFF
--- a/src/main/java/nextstep/subway/exceptions/InvalidCostException.java
+++ b/src/main/java/nextstep/subway/exceptions/InvalidCostException.java
@@ -1,0 +1,13 @@
+package nextstep.subway.exceptions;
+
+public class InvalidCostException extends RuntimeException {
+    public static final String DEFAULT_MSG = "운임 요금은 0원 이상이어야 합니다.";
+
+    public InvalidCostException() {
+        super(DEFAULT_MSG);
+    }
+
+    public InvalidCostException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -28,12 +28,6 @@ public class Section {
     public Section() {
     }
 
-    public Section(Line line, Station upStation, Station downStation, int distance) {
-        this.line = line;
-        this.upStation = upStation;
-        this.downStation = downStation;
-        this.distance = distance;
-    }
 
     public Section(Line line, Station upStation, Station downStation, int distance, int duration) {
         this.line = line;

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -125,7 +125,8 @@ public class Sections {
             Station newUpStation = downLineStation.get().getUpStation();
             Station newDownStation = upLineStation.get().getDownStation();
             int newDistance = upLineStation.get().getDistance() + downLineStation.get().getDistance();
-            sections.add(new Section(upLineStation.get().getLine(), newUpStation, newDownStation, newDistance));
+            int newDuration = upLineStation.get().getDistance() + downLineStation.get().getDistance();
+            sections.add(new Section(upLineStation.get().getLine(), newUpStation, newDownStation, newDistance, newDuration));
         }
 
         upLineStation.ifPresent(it -> sections.remove(it));

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -125,7 +125,7 @@ public class Sections {
             Station newUpStation = downLineStation.get().getUpStation();
             Station newDownStation = upLineStation.get().getDownStation();
             int newDistance = upLineStation.get().getDistance() + downLineStation.get().getDistance();
-            int newDuration = upLineStation.get().getDistance() + downLineStation.get().getDistance();
+            int newDuration = upLineStation.get().getDuration() + downLineStation.get().getDuration();
             sections.add(new Section(upLineStation.get().getLine(), newUpStation, newDownStation, newDistance, newDuration));
         }
 

--- a/src/main/java/nextstep/subway/path/application/PathService.java
+++ b/src/main/java/nextstep/subway/path/application/PathService.java
@@ -1,7 +1,9 @@
 package nextstep.subway.path.application;
 
 import nextstep.subway.line.domain.PathType;
+import nextstep.subway.path.domain.Cost;
 import nextstep.subway.path.domain.PathResult;
+import nextstep.subway.path.domain.PaymentPolicy;
 import nextstep.subway.path.domain.SubwayGraph;
 import nextstep.subway.path.dto.PathResponse;
 import nextstep.subway.station.application.StationService;
@@ -12,10 +14,12 @@ import org.springframework.stereotype.Service;
 public class PathService {
     private GraphService graphService;
     private StationService stationService;
+    private PaymentPolicy paymentPolicy;
 
-    public PathService(GraphService graphService, StationService stationService) {
+    public PathService(GraphService graphService, StationService stationService, PaymentPolicy paymentPolicy) {
         this.graphService = graphService;
         this.stationService = stationService;
+        this.paymentPolicy = paymentPolicy;
     }
 
     public PathResponse findPath(Long source, Long target, PathType type) {
@@ -23,6 +27,7 @@ public class PathService {
         Station sourceStation = stationService.findStationById(source);
         Station targetStation = stationService.findStationById(target);
         PathResult pathResult = subwayGraph.findPath(sourceStation, targetStation);
-        return PathResponse.of(pathResult);
+        Cost cost = paymentPolicy.cost(pathResult);
+        return PathResponse.of(pathResult, cost);
     }
 }

--- a/src/main/java/nextstep/subway/path/domain/Cost.java
+++ b/src/main/java/nextstep/subway/path/domain/Cost.java
@@ -1,0 +1,22 @@
+package nextstep.subway.path.domain;
+
+import nextstep.subway.exceptions.InvalidCostException;
+
+public class Cost {
+    private long cost;
+
+    public Cost(long cost) {
+        isValidCost(cost);
+        this.cost = cost;
+    }
+
+    private void isValidCost(long cost) {
+        if (cost < 0) {
+            throw new InvalidCostException();
+        }
+    }
+
+    public long getCost() {
+        return cost;
+    }
+}

--- a/src/main/java/nextstep/subway/path/domain/DistancePaymentPolicy.java
+++ b/src/main/java/nextstep/subway/path/domain/DistancePaymentPolicy.java
@@ -1,0 +1,26 @@
+package nextstep.subway.path.domain;
+
+import org.springframework.stereotype.Component;
+
+import static nextstep.subway.path.domain.PaymentPolicy.*;
+
+@Component
+public class DistancePaymentPolicy implements PaymentPolicy {
+    public static final int COST_DELIMITER_50 = 8;
+    public static final int COST_DELIMITER_10 = 5;
+
+
+    @Override
+    public Cost cost(PathResult pathResult) {
+        int distance = pathResult.getTotalDistance();
+        if (distance > 50) {
+            int distanceOver50 = distance - 50;
+            int discountOver10AndUnder50 = distance - distanceOver50 - 10;
+            return new Cost(sum(calculateOverFare(distanceOver50, COST_DELIMITER_50) + calculateOverFare(discountOver10AndUnder50, COST_DELIMITER_10)));
+        }
+        if (distance > 10) {
+            return new Cost(sum(calculateOverFare(distance - 10, COST_DELIMITER_10)));
+        }
+        return new Cost(DEFAULT_COST);
+    }
+}

--- a/src/main/java/nextstep/subway/path/domain/PathResult.java
+++ b/src/main/java/nextstep/subway/path/domain/PathResult.java
@@ -2,18 +2,21 @@ package nextstep.subway.path.domain;
 
 import nextstep.subway.line.domain.Sections;
 import nextstep.subway.station.domain.Station;
+import nextstep.subway.station.domain.Stations;
 
 import java.util.List;
 
 public class PathResult {
     private Sections sections;
+    private Stations stations;
 
-    public PathResult(Sections sections) {
+    public PathResult(Stations stations, Sections sections) {
+        this.stations = stations;
         this.sections = sections;
     }
 
     public List<Station> getStations() {
-        return sections.getStations();
+        return stations.getStations();
     }
 
     public int getTotalDistance() {

--- a/src/main/java/nextstep/subway/path/domain/PaymentPolicy.java
+++ b/src/main/java/nextstep/subway/path/domain/PaymentPolicy.java
@@ -1,0 +1,18 @@
+package nextstep.subway.path.domain;
+
+import java.util.Arrays;
+
+public interface PaymentPolicy {
+    long DEFAULT_COST = 1250;
+
+    Cost cost(PathResult pathResult);
+
+    static long sum(long... values) {
+        long sum = Arrays.stream(values).sum();
+        return DEFAULT_COST + sum;
+    }
+
+    static long calculateOverFare(int distance, double delimiter) {
+        return (long) (Math.ceil(distance / delimiter) * 100);
+    }
+}

--- a/src/main/java/nextstep/subway/path/domain/SubwayGraph.java
+++ b/src/main/java/nextstep/subway/path/domain/SubwayGraph.java
@@ -5,6 +5,7 @@ import nextstep.subway.line.domain.PathType;
 import nextstep.subway.line.domain.Section;
 import nextstep.subway.line.domain.Sections;
 import nextstep.subway.station.domain.Station;
+import nextstep.subway.station.domain.Stations;
 import org.jgrapht.GraphPath;
 import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
 import org.jgrapht.graph.WeightedMultigraph;
@@ -45,6 +46,6 @@ public class SubwayGraph {
                 .map(it -> it.getSection())
                 .collect(Collectors.toList());
 
-        return new PathResult(new Sections(sections));
+        return new PathResult(new Stations(result.getVertexList()), new Sections(sections));
     }
 }

--- a/src/main/java/nextstep/subway/path/dto/PathResponse.java
+++ b/src/main/java/nextstep/subway/path/dto/PathResponse.java
@@ -1,5 +1,6 @@
 package nextstep.subway.path.dto;
 
+import nextstep.subway.path.domain.Cost;
 import nextstep.subway.path.domain.PathResult;
 import nextstep.subway.station.dto.StationResponse;
 
@@ -9,20 +10,22 @@ public class PathResponse {
     private List<StationResponse> stations;
     private int distance;
     private int duration;
+    private long cost;
 
     public PathResponse() {
     }
 
-    public PathResponse(List<StationResponse> stations, int distance, int duration) {
+    public PathResponse(List<StationResponse> stations, int distance, int duration, long cost) {
         this.stations = stations;
         this.distance = distance;
         this.duration = duration;
+        this.cost = cost;
     }
 
-    public static PathResponse of(PathResult pathResult) {
+    public static PathResponse of(PathResult pathResult, Cost cost) {
         int distance = pathResult.getTotalDistance();
         int duration = pathResult.getTotalDuration();
-        return new PathResponse(StationResponse.listOf(pathResult.getStations()), distance, duration);
+        return new PathResponse(StationResponse.listOf(pathResult.getStations()), distance, duration, cost.getCost());
     }
 
     public List<StationResponse> getStations() {
@@ -35,5 +38,9 @@ public class PathResponse {
 
     public int getDuration() {
         return duration;
+    }
+
+    public long getCost() {
+        return cost;
     }
 }

--- a/src/main/java/nextstep/subway/station/domain/Stations.java
+++ b/src/main/java/nextstep/subway/station/domain/Stations.java
@@ -1,0 +1,15 @@
+package nextstep.subway.station.domain;
+
+import java.util.List;
+
+public class Stations {
+    private List<Station> stations;
+
+    public Stations(List<Station> stations) {
+        this.stations = stations;
+    }
+
+    public List<Station> getStations() {
+        return stations;
+    }
+}

--- a/src/test/java/nextstep/subway/path/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/path/acceptance/PathAcceptanceTest.java
@@ -10,6 +10,8 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Arrays;
+
 import static nextstep.subway.line.acceptance.LineSteps.지하철_노선에_지하철역_등록_요청;
 import static nextstep.subway.path.acceptance.PathSteps.*;
 import static nextstep.subway.station.StationSteps.지하철역_등록되어_있음;
@@ -23,6 +25,14 @@ public class PathAcceptanceTest extends AcceptanceTest {
     private LineResponse 이호선;
     private LineResponse 신분당선;
     private LineResponse 삼호선;
+
+    /**
+     * 교대역    --- *2호선* ---   강남역
+     * |                        |
+     * *3호선*                   *신분당선*
+     * |                        |
+     * 남부터미널역  --- *3호선* ---   양재
+     */
 
     @BeforeEach
     public void setUp() {
@@ -44,10 +54,10 @@ public class PathAcceptanceTest extends AcceptanceTest {
     @Test
     void findPathByDistance() {
         // when
-        ExtractableResponse<Response> response = 두_역의_최단_거리_경로_조회를_요청(교대역.getId(), 양재역.getId());
+        ExtractableResponse<Response> response = 두_역의_최단_거리_경로_조회를_요청(양재역.getId(),교대역 .getId());
 
         // then
-        경로_응답됨(response, Lists.newArrayList(교대역.getId(), 남부터미널역.getId(), 양재역.getId()), 5, 20);
+        경로_응답됨(response, Lists.newArrayList(양재역.getId(), 남부터미널역.getId(), 교대역.getId()), 5, 20);
     }
 
     @DisplayName("두 역의 최단 거리 경로를 조회한다.")
@@ -58,5 +68,19 @@ public class PathAcceptanceTest extends AcceptanceTest {
 
         // then
         경로_응답됨(response, Lists.newArrayList(교대역.getId(), 강남역.getId(), 양재역.getId()), 20, 20);
+    }
+
+
+    @DisplayName("두 역의 최단 거리 경로를 조회한다.")
+    @Test
+    void managePathFinder() {
+        //when
+        ExtractableResponse<Response> pathFindResponse = 두_역의_최단_거리_경로_조회를_요청(양재역.getId(), 교대역.getId());
+
+        //then
+        경로_응답됨(pathFindResponse, Arrays.asList(양재역.getId(), 남부터미널역.getId(), 교대역.getId()), 5, 20);
+
+        경로_요금_일치함(pathFindResponse, 1250);
+
     }
 }

--- a/src/test/java/nextstep/subway/path/acceptance/PathSteps.java
+++ b/src/test/java/nextstep/subway/path/acceptance/PathSteps.java
@@ -80,7 +80,8 @@ public class PathSteps {
                 fieldWithPath("stations[].createdDate").description("지하철 역 생성일"),
                 fieldWithPath("stations[].modifiedDate").description("지하철 역 최종 변경일"),
                 fieldWithPath("distance").description("경로 구간 길이"),
-                fieldWithPath("duration").description("경로 구간 소요 시간")
+                fieldWithPath("duration").description("경로 구간 소요 시간"),
+                fieldWithPath("cost").description("경로 구간 지불해야하는 금액")
         );
     }
 
@@ -100,5 +101,11 @@ public class PathSteps {
                 .filter(document("{method-name}",
                         지하철_노선_경로탐색_파라미터_설명(),
                         지하철_노선_경로탐색_결과_필드_설명()));
+    }
+
+    public static void 경로_요금_일치함(ExtractableResponse<Response> response, int fee) {
+        PathResponse pathResponse = response.as(PathResponse.class);
+
+        assertThat(pathResponse.getCost()).isEqualTo(fee);
     }
 }

--- a/src/test/java/nextstep/subway/path/acceptance/PathSteps.java
+++ b/src/test/java/nextstep/subway/path/acceptance/PathSteps.java
@@ -3,6 +3,7 @@ package nextstep.subway.path.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.path.dto.PathResponse;
@@ -20,6 +21,7 @@ import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 public class PathSteps {
     public static LineResponse 지하철_노선_등록되어_있음(String name, String color, StationResponse upStation, StationResponse downStation, int distance, int duration) {
@@ -80,5 +82,23 @@ public class PathSteps {
                 fieldWithPath("distance").description("경로 구간 길이"),
                 fieldWithPath("duration").description("경로 구간 소요 시간")
         );
+    }
+
+    public static ExtractableResponse<Response> 두_역의_최단거리_탐색_요청(RequestSpecification spec, Long source, Long target) {
+        return given(spec)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("source", source)
+                .queryParam("target", target)
+                .queryParam("type", "DISTANCE")
+                .when().get("/paths")
+                .then().log().all().extract();
+    }
+
+    private static RequestSpecification given(RequestSpecification spec) {
+        return RestAssured
+                .given(spec)
+                .filter(document("{method-name}",
+                        지하철_노선_경로탐색_파라미터_설명(),
+                        지하철_노선_경로탐색_결과_필드_설명()));
     }
 }

--- a/src/test/java/nextstep/subway/path/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/path/documentation/PathDocumentation.java
@@ -36,21 +36,22 @@ public class PathDocumentation extends Documentation {
         양재역 = 지하철역_등록되어_있음("양재역").as(StationResponse.class);
         남부터미널역 = 지하철역_등록되어_있음("남부터미널역").as(StationResponse.class);
 
-        LineResponse 이호선 = 지하철_노선_등록되어_있음("2호선", "green", 교대역, 강남역, 10, 10);
-        LineResponse 신분당선 = 지하철_노선_등록되어_있음("신분당선", "green", 강남역, 양재역, 10, 10);
-        삼호선 = 지하철_노선_등록되어_있음("3호선", "green", 교대역, 남부터미널역, 2, 10);
+        LineResponse 이호선 = 지하철_노선_등록되어_있음("2호선", "green", 교대역, 강남역, 70, 70);
+        LineResponse 신분당선 = 지하철_노선_등록되어_있음("신분당선", "green", 강남역, 양재역, 30, 30);
+        삼호선 = 지하철_노선_등록되어_있음("3호선", "green", 교대역, 남부터미널역, 16, 16);
 
-        지하철_노선에_지하철역_등록_요청(삼호선, 남부터미널역, 양재역, 3, 10);
+        지하철_노선에_지하철역_등록_요청(삼호선, 남부터미널역, 양재역, 22, 20);
     }
 
 
     @Test
     void path() {
         //when
-        ExtractableResponse<Response> response = 두_역의_최단거리_탐색_요청(spec, 교대역.getId(), 강남역.getId());
+        ExtractableResponse<Response> response = 두_역의_최단거리_탐색_요청(spec, 양재역.getId(), 교대역.getId());
 
         //then
-        경로_응답됨(response, Arrays.asList(교대역.getId(), 강남역.getId()), 10, 10);
+        경로_응답됨(response, Arrays.asList(양재역.getId(), 남부터미널역.getId(), 교대역.getId()), 38, 36);
+        PathSteps.경로_요금_일치함(response, 1850);
     }
 }
 

--- a/src/test/java/nextstep/subway/path/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/path/documentation/PathDocumentation.java
@@ -46,20 +46,10 @@ public class PathDocumentation extends Documentation {
 
     @Test
     void path() {
-        //then
-        ExtractableResponse<Response> response = RestAssured
-                .given(spec)
-                .filter(document("{method-name}",
-                        지하철_노선_경로탐색_파라미터_설명(),
-                        지하철_노선_경로탐색_결과_필드_설명()))
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .queryParam("source", 교대역.getId())
-                .queryParam("target", 강남역.getId())
-                .queryParam("type", "DISTANCE")
-                .when().get("/paths")
-                .then().log().all().extract();
-
         //when
+        ExtractableResponse<Response> response = 두_역의_최단거리_탐색_요청(spec, 교대역.getId(), 강남역.getId());
+
+        //then
         경로_응답됨(response, Arrays.asList(교대역.getId(), 강남역.getId()), 10, 10);
     }
 }

--- a/src/test/java/nextstep/subway/path/domain/SubwayGraphTest.java
+++ b/src/test/java/nextstep/subway/path/domain/SubwayGraphTest.java
@@ -1,0 +1,29 @@
+package nextstep.subway.path.domain;
+
+import com.google.common.collect.Lists;
+import nextstep.subway.line.domain.Line;
+import nextstep.subway.line.domain.PathType;
+import nextstep.subway.station.domain.Station;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class SubwayGraphTest {
+    @Test
+    void findPath() {
+        // given
+        Station 강남역 = new Station("강남역");
+        Station 역삼역 = new Station("역삼역");
+        Station 선릉역 = new Station("선릉역");
+        Line line = new Line("2호선", "green");
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(역삼역, 선릉역, 10, 10);
+        SubwayGraph subwayGraph = new SubwayGraph(Lists.newArrayList(line), PathType.DISTANCE);
+
+        // when
+        PathResult pathResult = subwayGraph.findPath(선릉역, 강남역);
+
+        // then
+        assertThat(pathResult.getStations()).containsExactly(선릉역, 역삼역, 강남역);
+    }
+}


### PR DESCRIPTION
안녕하세요. 성현님 2단계 미션 PR입니다. 
우선, 뼈대코드 업데이트내용 반영을 한 뒤 미션 적용을 했습니다. 

1. 1단계에서 피드백 주신 내용 적용
    - 문서화 메서드 모듈화
    - API요청 부분자체 PathSteps로 메서드화해서 분리
2. 2단계 미션 요금 조회 기능 구현
    - 인수테스트에 추가된 요금관련 필드 설명 추가
    - 인수테스트 작성
    - 요금 일급객체 Cost 구현
    - 요금정책 인터페이스 PaymentPolicy 구현
    - 요금정책 거리기반 구현체 DistancePaymentPolicy 구현
    - 경로서비스(PathService)에서 새로 의존관계 주입받은 요금정책빈을 통해 요금 조회기능 로직 추가

5km마다 100원씩 추가되는 요금 연산식에서 ceil로 올림을 하는데 -1한 뒤 다시 +1 하는것보다는 Delimiter 로 사용되는 인자(distance delimiter인 5km, 8km)를 double형으로 만들어서 사용했는데 테스트에서는 문제가안되는데 괜찮은지 모르겠습니다.

이번과정에서 고민했던게 해당 요금정책 빈을 컴포넌트로 선언해서 인터페이스를 만들어 의존성 주입을 해줬는데, 
enum으로 만들어서 해도 상관이없었을것 같다는 생각이들어 고민을 무엇으로 할지 고민을 했습니다. 
