### PR TITLE
[Step3] 🚀 3단계 - 요금 정책 추가

### DIFF
--- a/src/main/java/nextstep/subway/auth/application/UserDetailsService.java
+++ b/src/main/java/nextstep/subway/auth/application/UserDetailsService.java
@@ -2,4 +2,6 @@ package nextstep.subway.auth.application;
 
 public interface UserDetailsService {
     UserDetails loadUserByUsername(String principal);
+
+    UserDetails anonymousMember();
 }

--- a/src/main/java/nextstep/subway/auth/infrastructure/AuthConfig.java
+++ b/src/main/java/nextstep/subway/auth/infrastructure/AuthConfig.java
@@ -32,6 +32,6 @@ public class AuthConfig implements WebMvcConfigurer {
 
     @Override
     public void addArgumentResolvers(List argumentResolvers) {
-        argumentResolvers.add(new AuthenticationPrincipalArgumentResolver());
+        argumentResolvers.add(new AuthenticationPrincipalArgumentResolver(userDetailsService));
     }
 }

--- a/src/main/java/nextstep/subway/auth/ui/authorization/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/nextstep/subway/auth/ui/authorization/AuthenticationPrincipalArgumentResolver.java
@@ -1,5 +1,6 @@
 package nextstep.subway.auth.ui.authorization;
 
+import nextstep.subway.auth.application.UserDetailsService;
 import nextstep.subway.auth.domain.Authentication;
 import nextstep.subway.auth.domain.AuthenticationPrincipal;
 import nextstep.subway.auth.infrastructure.SecurityContextHolder;
@@ -13,6 +14,13 @@ import java.util.Arrays;
 import java.util.Map;
 
 public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final UserDetailsService userDetailsService;
+
+    public AuthenticationPrincipalArgumentResolver(UserDetailsService userDetailsService) {
+        this.userDetailsService = userDetailsService;
+    }
+
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
         return parameter.hasParameterAnnotation(AuthenticationPrincipal.class);
@@ -21,6 +29,11 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null) {
+            return userDetailsService.anonymousMember();
+        }
+
         if (authentication.getPrincipal() instanceof Map) {
             return extractPrincipal(parameter, authentication);
         }

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -15,6 +15,7 @@ public class Line extends BaseEntity {
     @Column(unique = true)
     private String name;
     private String color;
+    private int overFare;
 
     @Embedded
     private Sections sections = new Sections();
@@ -25,6 +26,13 @@ public class Line extends BaseEntity {
     public Line(String name, String color) {
         this.name = name;
         this.color = color;
+    }
+
+    public Line(Long id, String name, String color, int overFare) {
+        this.id = id;
+        this.name = name;
+        this.color = color;
+        this.overFare = overFare;
     }
 
     public void update(Line line) {
@@ -50,6 +58,10 @@ public class Line extends BaseEntity {
 
     public List<Station> getStations() {
         return sections.getStations();
+    }
+
+    public int getOverFare() {
+        return overFare;
     }
 
     public void addSection(Station upStation, Station downStation, int distance, int duration) {

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -6,10 +6,7 @@ import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
 import javax.persistence.FetchType;
 import javax.persistence.OneToMany;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 
 @Embeddable
 public class Sections {
@@ -131,6 +128,13 @@ public class Sections {
 
         upLineStation.ifPresent(it -> sections.remove(it));
         downLineStation.ifPresent(it -> sections.remove(it));
+    }
+
+    public int getMaxOverFare() {
+        return sections.stream()
+                .mapToInt(it -> it.getLine().getOverFare())
+                .max()
+                .orElseThrow(NoSuchElementException::new);
     }
 
     public int getTotalDistance() {

--- a/src/main/java/nextstep/subway/line/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/line/dto/LineRequest.java
@@ -7,6 +7,7 @@ public class LineRequest {
     private Long downStationId;
     private int distance;
     private int duration;
+    private int overFare;
 
     public LineRequest() {
     }
@@ -18,6 +19,17 @@ public class LineRequest {
         this.downStationId = downStationId;
         this.distance = distance;
         this.duration = duration;
+    }
+
+    public LineRequest(String name, String color, Long upStationId,
+                       Long downStationId, int distance, int duration, int overFare) {
+        this.name = name;
+        this.color = color;
+        this.upStationId = upStationId;
+        this.downStationId = downStationId;
+        this.distance = distance;
+        this.duration = duration;
+        this.overFare = overFare;
     }
 
     public String getName() {
@@ -42,5 +54,9 @@ public class LineRequest {
 
     public int getDuration() {
         return duration;
+    }
+
+    public int getOverFare() {
+        return overFare;
     }
 }

--- a/src/main/java/nextstep/subway/member/application/CustomUserDetailsService.java
+++ b/src/main/java/nextstep/subway/member/application/CustomUserDetailsService.java
@@ -1,6 +1,8 @@
 package nextstep.subway.member.application;
 
+import nextstep.subway.auth.application.UserDetails;
 import nextstep.subway.auth.application.UserDetailsService;
+import nextstep.subway.member.domain.AnonymousMember;
 import nextstep.subway.member.domain.LoginMember;
 import nextstep.subway.member.domain.Member;
 import nextstep.subway.member.domain.MemberRepository;
@@ -17,5 +19,10 @@ public class CustomUserDetailsService implements UserDetailsService {
     public LoginMember loadUserByUsername(String email) {
         Member member = memberRepository.findByEmail(email).orElseThrow(RuntimeException::new);
         return LoginMember.of(member);
+    }
+
+    @Override
+    public UserDetails anonymousMember() {
+        return new AnonymousMember();
     }
 }

--- a/src/main/java/nextstep/subway/member/domain/AnonymousMember.java
+++ b/src/main/java/nextstep/subway/member/domain/AnonymousMember.java
@@ -1,0 +1,10 @@
+package nextstep.subway.member.domain;
+
+public class AnonymousMember extends LoginMember{
+
+    public static final String ANONYMOUS = "ANONYMOUS";
+
+    public AnonymousMember() {
+        super(null, ANONYMOUS, ANONYMOUS, 20);
+    }
+}

--- a/src/main/java/nextstep/subway/path/application/PathService.java
+++ b/src/main/java/nextstep/subway/path/application/PathService.java
@@ -19,13 +19,13 @@ public class PathService {
         this.stationService = stationService;
     }
 
-    public PathResponse findPath(Long source, Long target, PathType type) {
+    public PathResponse findPath(Long source, Long target, PathType type, int age) {
         SubwayGraph subwayGraph = graphService.findGraph(type);
         Station sourceStation = stationService.findStationById(source);
         Station targetStation = stationService.findStationById(target);
 
         PathResult pathResult = subwayGraph.findPath(sourceStation, targetStation);
-        Fare fare = new Fare(pathResult.getTotalDistance());
+        Fare fare = new Fare(pathResult.getTotalDistance(), age, pathResult.getMaxOverFare());
 
         return PathResponse.of(pathResult, fare);
     }

--- a/src/main/java/nextstep/subway/path/domain/AgeOfFareType.java
+++ b/src/main/java/nextstep/subway/path/domain/AgeOfFareType.java
@@ -1,0 +1,39 @@
+package nextstep.subway.path.domain;
+
+import java.util.Arrays;
+import java.util.function.Function;
+
+public enum AgeOfFareType {
+
+    CHILDREN_FARE(350,0.5, age -> age >= 6 && age < 13),
+    TEENAGER_FARE(350,0.8, age -> age >= 13 && age < 19),
+    ADULT_FARE(0,1.0, age -> age >= 19);
+
+    private int discountFare;
+    private double discountRate;
+    private Function<Integer, Boolean> ageType;
+
+    AgeOfFareType(int discountFare, double discountRate, Function<Integer, Boolean> ageType) {
+        this.discountFare = discountFare;
+        this.discountRate = discountRate;
+        this.ageType = ageType;
+    }
+
+    private static AgeOfFareType valueOf(int age) {
+        return Arrays.stream(AgeOfFareType.values())
+                .filter(it -> it.isAgeType(age))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("나이는 0보다 커야 합니다."));
+    }
+
+    public boolean isAgeType(int age) {
+        return ageType.apply(age);
+    }
+
+    public static int calculate(int fare, int age) {
+        AgeOfFareType ageOfFareType = valueOf(age);
+
+        int discountedOverFare = (int) ((fare - ageOfFareType.discountFare) * ageOfFareType.discountRate);
+        return discountedOverFare;
+    }
+}

--- a/src/main/java/nextstep/subway/path/domain/Fare.java
+++ b/src/main/java/nextstep/subway/path/domain/Fare.java
@@ -2,16 +2,18 @@ package nextstep.subway.path.domain;
 
 public class Fare {
 
-    private final int BASIC_FARE = 1250;
+    private final static int BASIC_FARE = 1250;
     private final int fare;
 
-    public Fare(int distance) {
-        this.fare = BASIC_FARE + calculateOverFare(distance);
+    public Fare(int distance, int age, int overFare) {
+        this.fare = calculateFare(distance, age, overFare);
     }
 
-    private int calculateOverFare(int distance) {
+    private int calculateFare(int distance, int age, int overFare) {
         DistanceOfFareType distanceOfFareType = DistanceOfFareType.valueOf(distance);
-        return distanceOfFareType.calculate(distance);
+        int calculateDistanceFare = BASIC_FARE + overFare + distanceOfFareType.calculate(distance);
+
+        return AgeOfFareType.calculate(calculateDistanceFare, age);
     }
 
     public int getFare() {

--- a/src/main/java/nextstep/subway/path/domain/PathResult.java
+++ b/src/main/java/nextstep/subway/path/domain/PathResult.java
@@ -23,4 +23,6 @@ public class PathResult {
     public int getTotalDuration() {
         return sections.getTotalDuration();
     }
+
+    public int getMaxOverFare() { return sections.getMaxOverFare(); }
 }

--- a/src/main/java/nextstep/subway/path/ui/PathController.java
+++ b/src/main/java/nextstep/subway/path/ui/PathController.java
@@ -1,6 +1,8 @@
 package nextstep.subway.path.ui;
 
+import nextstep.subway.auth.domain.AuthenticationPrincipal;
 import nextstep.subway.line.domain.PathType;
+import nextstep.subway.member.domain.LoginMember;
 import nextstep.subway.path.application.PathService;
 import nextstep.subway.path.dto.PathResponse;
 import org.springframework.http.ResponseEntity;
@@ -17,7 +19,9 @@ public class PathController {
     }
 
     @GetMapping("/paths")
-    public ResponseEntity<PathResponse> findPath(@RequestParam Long source, @RequestParam Long target, @RequestParam PathType type) {
-        return ResponseEntity.ok(pathService.findPath(source, target, type));
+    public ResponseEntity<PathResponse> findPath(@RequestParam Long source, @RequestParam Long target,
+                                                 @RequestParam PathType type, @AuthenticationPrincipal LoginMember loginMember) {
+
+        return ResponseEntity.ok(pathService.findPath(source, target, type, loginMember.getAge()));
     }
 }

--- a/src/test/java/nextstep/subway/path/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/path/acceptance/PathAcceptanceTest.java
@@ -20,7 +20,6 @@ import static nextstep.subway.station.StationSteps.지하철역_등록되어_있
 public class PathAcceptanceTest extends AcceptanceTest {
     public static final String EMAIL = "email@email.com";
     public static final String PASSWORD = "password";
-    public static final int AGE = 20;
     public static final int YOUNG_AGE = 13;
 
     private StationResponse 교대역;

--- a/src/test/java/nextstep/subway/path/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/path/acceptance/PathAcceptanceTest.java
@@ -4,6 +4,7 @@ import com.google.common.collect.Lists;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.auth.dto.TokenResponse;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.station.dto.StationResponse;
 import org.junit.jupiter.api.BeforeEach;
@@ -11,11 +12,17 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import static nextstep.subway.line.acceptance.LineSteps.지하철_노선에_지하철역_등록_요청;
+import static nextstep.subway.member.MemberSteps.*;
 import static nextstep.subway.path.acceptance.PathSteps.*;
 import static nextstep.subway.station.StationSteps.지하철역_등록되어_있음;
 
 @DisplayName("지하철 경로 검색")
 public class PathAcceptanceTest extends AcceptanceTest {
+    public static final String EMAIL = "email@email.com";
+    public static final String PASSWORD = "password";
+    public static final int AGE = 20;
+    public static final int YOUNG_AGE = 13;
+
     private StationResponse 교대역;
     private StationResponse 강남역;
     private StationResponse 양재역;
@@ -59,5 +66,22 @@ public class PathAcceptanceTest extends AcceptanceTest {
         경로_응답됨(durationResponse, Lists.newArrayList(교대역.getId(), 강남역.getId(), 양재역.getId()));
         총_거리와_소요_시간을_함께_응답함(durationResponse, 20, 20);
         이용요금도_함께_응답함(durationResponse, 1450);
+    }
+
+    @DisplayName("로그인한 사용자가 최단 경로를 조회")
+    @Test
+    void findUserPaths() {
+        // given
+        ExtractableResponse<Response> createResponse = 회원_생성_요청(EMAIL, PASSWORD, YOUNG_AGE);
+        회원_생성됨(createResponse);
+        TokenResponse tokenResponse = 로그인_되어_있음(EMAIL, PASSWORD);
+
+        // when
+        ExtractableResponse<Response> response = 로그인한_사용자가_두_역의_최단_거리_경로_조회를_요청(교대역.getId(), 양재역.getId(), "DISTANCE", tokenResponse);
+
+        // then
+        경로_응답됨(response, Lists.newArrayList(교대역.getId(), 남부터미널역.getId(), 양재역.getId()));
+        총_거리와_소요_시간을_함께_응답함(response,5, 20);
+        이용요금도_함께_응답함(response, 720);
     }
 }

--- a/src/test/java/nextstep/subway/path/acceptance/PathSteps.java
+++ b/src/test/java/nextstep/subway/path/acceptance/PathSteps.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
+import nextstep.subway.auth.dto.TokenResponse;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.path.dto.PathResponse;
@@ -42,6 +43,18 @@ public class PathSteps extends Documentation {
                 .queryParam("source", source)
                 .queryParam("target", target)
                 .queryParam("type", "DISTANCE")
+                .when().get("/paths")
+                .then().log().all().extract();
+    }
+
+    public static ExtractableResponse<Response> 로그인한_사용자가_두_역의_최단_거리_경로_조회를_요청(Long source, Long target, String type, TokenResponse tokenResponse) {
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(tokenResponse.getAccessToken())
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("source", source)
+                .queryParam("target", target)
+                .queryParam("type", type)
                 .when().get("/paths")
                 .then().log().all().extract();
     }

--- a/src/test/java/nextstep/subway/path/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/path/documentation/PathDocumentation.java
@@ -38,10 +38,10 @@ public class PathDocumentation extends Documentation {
                 new StationResponse(2L, "양재역", LocalDateTime.now(), LocalDateTime.now())
         );
 
-        Fare fare = new Fare(10);
+        Fare fare = new Fare(10, 19, 0);
         PathResponse pathResponse = new PathResponse(stations, 10, 10, fare.getFare());
 
-        when(pathService.findPath(anyLong(), anyLong(), any())).thenReturn(pathResponse);
+        when(pathService.findPath(anyLong(), anyLong(), any(), anyInt())).thenReturn(pathResponse);
 
         두_역의_최단_거리_경로_조회를_요청(경로_문서화_요청(), 1L, 2L);
     }

--- a/src/test/java/nextstep/subway/path/domain/AgeOfFareTypeTest.java
+++ b/src/test/java/nextstep/subway/path/domain/AgeOfFareTypeTest.java
@@ -1,0 +1,32 @@
+package nextstep.subway.path.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AgeOfFareTypeTest {
+
+    @DisplayName("원하는 할인 요금이 나온다.")
+    @Test
+    void ageFareType() {
+
+        // given
+        int childrenFare = AgeOfFareType.calculate(1250, 6);
+
+        // then
+        assertThat(childrenFare).isEqualTo(450);
+
+        // given
+        int teenagerFare = AgeOfFareType.calculate(1250, 15);
+
+        // then
+        assertThat(teenagerFare).isEqualTo(720);
+
+        // given
+        int adultFare = AgeOfFareType.calculate(1250, 20);
+
+        // then
+        assertThat(adultFare).isEqualTo(1250);
+    }
+}

--- a/src/test/java/nextstep/subway/path/domain/DistanceOfTypeTest.java
+++ b/src/test/java/nextstep/subway/path/domain/DistanceOfTypeTest.java
@@ -1,0 +1,35 @@
+package nextstep.subway.path.domain;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class DistanceOfTypeTest {
+
+    @DisplayName("원하는 추가요금이 나온다")
+    @Test
+    void distanceType() {
+
+        // given Basic Fare
+        DistanceOfFareType basicDistanceOfFareType = DistanceOfFareType.valueOf(10);
+
+        // then
+        assertThat(basicDistanceOfFareType.name()).isEqualTo(DistanceOfFareType.BASIC_FARE.toString());
+        assertThat(basicDistanceOfFareType.calculate(10)).isEqualTo(0);
+
+        // given TEN_KM_OVER_FARE
+        DistanceOfFareType tenKmOverFare = DistanceOfFareType.valueOf(20);
+
+        // then
+        assertThat(tenKmOverFare.name()).isEqualTo(DistanceOfFareType.TEN_KM_OVER_FARE.toString());
+        assertThat(tenKmOverFare.calculate(20)).isEqualTo(200);
+
+        // given FIFTY_KM_OVER_FARE
+        DistanceOfFareType fiftyKmOverFare = DistanceOfFareType.valueOf(60);
+
+        // then
+        assertThat(fiftyKmOverFare.name()).isEqualTo(DistanceOfFareType.FIFTY_KM_OVER_FARE.toString());
+        assertThat(fiftyKmOverFare.calculate(60)).isEqualTo(1000);
+    }
+}

--- a/src/test/java/nextstep/subway/path/domain/FareTest.java
+++ b/src/test/java/nextstep/subway/path/domain/FareTest.java
@@ -13,19 +13,50 @@ public class FareTest {
     @ParameterizedTest
     @DisplayName("요금 거리별 계산")
     @CsvSource(value = {
-            "10,1250",
-            "20,1450",
-            "58,2150"
+            "20,10,0,1250",
+            "20,20,0,1450",
+            "20,58,0,2150"
     })
-    void calculate(int distance, int fare) {
-        Fare actual = new Fare(distance);
+    void calculate(int age, int distance, int overFare, int fare) {
+        Fare actual = new Fare(distance, age, overFare);
+        assertThat(actual.getFare()).isEqualTo(fare);
+    }
+
+    @ParameterizedTest
+    @DisplayName("요금 나이별 계산")
+    @CsvSource(value = {
+            "6,10,0,450",
+            "13,10,0,720",
+            "20,10,0,1250"
+    })
+    void calculateAge(int age, int distance, int overFare, int fare) {
+        Fare actual = new Fare(distance, age, overFare);
+        assertThat(actual.getFare()).isEqualTo(fare);
+    }
+
+    @ParameterizedTest
+    @DisplayName("요금 추가요금별 계산")
+    @CsvSource(value = {
+            "20,10,0,1250",
+            "20,10,100,1350",
+            "20,10,1000,2250"
+    })
+    void calculateOverFare(int age, int distance, int overFare, int fare) {
+        Fare actual = new Fare(distance, age, overFare);
         assertThat(actual.getFare()).isEqualTo(fare);
     }
 
     @DisplayName("거리가 0보다 작은 경우")
     @Test
     void validateDistanceLessThanZero() {
-        assertThatThrownBy(() -> {new Fare(0); })
+        assertThatThrownBy(() -> {new Fare(0, 20, 0); })
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @DisplayName("나이가 0보다 작은 경우")
+    @Test
+    void validateAgeLessThanZero() {
+        assertThatThrownBy(() -> {new Fare(10, 0, 0); })
                 .isInstanceOf(IllegalArgumentException.class);
     }
 


### PR DESCRIPTION
step 3 요금 정책 추가 pr합니다! 리뷰 부탁드립니다 ㅎㅎ

- [x] 추가 요금이 있는 노선을 이용 할 경우 측정된 요금에 추가

- [x] 경로 중 추가요금이 있는 노선을 환승 하여 이용 할 경우 가장 높은 금액의 추가 요금만 적용

- [x] 로그인 사용자의 경우 연령별 요금으로 계산

나이 별 요금 정책도 enum을 사용해서 계산하였습니다! 개인적으로 enum을 많이 사용해 본적이 없었는데 이번 주차에서 많이 쓰게 되어 재밌었습니다.

로그인 안한 사용자의 경우 고민을 많이 했었는데 null 객체를 만들어서 해결하게 되었습니다
브라운님이 @AuthenticationPrincipal(required=false)을 써보라고 힌트를 주셨는데 결국 적용하지 못하고....
AuthenticationPrincipalArgumentResolver에서 null일 경우 null 객체를 만들어서 리턴해주는 방식으로 하게 되었네요 ㅎㅎ

예외 상황이나 여러가지 시나리오를 가정해 두고 테스트를 잘 만들어야 겠다는 생각이 많이 들었습니다
감사합니다!