### PR TITLE
Step 1

### DIFF
--- a/src/docs/asciidoc/path.adoc
+++ b/src/docs/asciidoc/path.adoc
@@ -6,6 +6,7 @@
 ==== Request
 
 include::{snippets}/path/http-request.adoc[]
+include::{snippets}/path/request-parameters.adoc[]
 
 ==== Response
 

--- a/src/test/java/nextstep/subway/path/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/path/documentation/PathDocumentation.java
@@ -2,16 +2,51 @@ package nextstep.subway.path.documentation;
 
 import io.restassured.RestAssured;
 import nextstep.subway.Documentation;
+import nextstep.subway.line.domain.PathType;
+import nextstep.subway.path.application.PathService;
+import nextstep.subway.path.dto.PathResponse;
+import nextstep.subway.station.dto.StationResponse;
+import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+import org.springframework.restdocs.operation.preprocess.Preprocessors;
+import org.springframework.restdocs.request.RequestDocumentation;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 public class PathDocumentation extends Documentation {
 
+    @MockBean
+    private PathService pathService;
+
     @Test
     void path() {
+        PathResponse pathResponse = new PathResponse(Lists.newArrayList(
+                new StationResponse(1L, "강남역", LocalDateTime.now(), LocalDateTime.now()),
+                new StationResponse(2L, "역삼역", LocalDateTime.now(), LocalDateTime.now()))
+                , 10, 10);
+
+        when(pathService.findPath(anyLong(), anyLong(), any(PathType.class))).thenReturn(pathResponse);
+
         RestAssured
-                .given().log().all()
-                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .given(spec).log().all()
+                .filter(document("path",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestParameters(
+                            parameterWithName("source").description("출발역 아이디"),
+                            parameterWithName("target").description("도착역 아이디"),
+                            parameterWithName("type").description("검색 기준")))
+                ).accept(MediaType.APPLICATION_JSON_VALUE)
                 .queryParam("source", 1L)
                 .queryParam("target", 2L)
                 .queryParam("type", "DISTANCE")


### PR DESCRIPTION
안녕하세요. 박병길이라고 합니다. 잘 부탁드립니다😊

조금 늦어졌지만 유종의 미를 거두려고 합니다.

restdocs 관련하여 질문이 있습니다.

`requestParameters()`를 사용하고 다른 snippet들 처럼 `src/docs/asciidoc/path.adoc`에 자동으로 파라미터 테이블이 들어가는 줄 알았는데 아닌 것 같았습니다. 직접 아래처럼 snippet을 입력하였는데 혹시 자동으로 하는 법이 있을까요? 
```
include::{snippets}/path/request-parameters.adoc[]
```

![image](https://user-images.githubusercontent.com/42828602/113177085-1de9c800-9288-11eb-882a-b4d9511773ef.png)
![image](https://user-images.githubusercontent.com/42828602/113177238-42de3b00-9288-11eb-86d2-e661eb21aca7.png)


