### PR TITLE
[인수 테스트와 리팩터링] 1단계 - 경로 조회 타입 추가

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -11,4 +11,4 @@
 
 === 경로 조회
 
-operation::path[snippets='http-request,http-response']
+operation::paths[snippets='http-request,request-parameters,http-response,response-fields']

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -30,7 +30,7 @@ public class LineService {
         if (request.getUpStationId() != null && request.getDownStationId() != null && request.getDistance() != 0) {
             Station upStation = stationService.findById(request.getUpStationId());
             Station downStation = stationService.findById(request.getDownStationId());
-            line.addSection(upStation, downStation, request.getDistance());
+            line.addSection(upStation, downStation, request.getDistance(), request.getDuration());
         }
         return LineResponse.of(line);
     }
@@ -70,7 +70,7 @@ public class LineService {
         Station downStation = stationService.findById(sectionRequest.getDownStationId());
         Line line = findById(lineId);
 
-        line.addSection(upStation, downStation, sectionRequest.getDistance());
+        line.addSection(upStation, downStation, sectionRequest.getDistance(), sectionRequest.getDuration());
     }
 
     private List<StationResponse> createStationResponses(Line line) {

--- a/src/main/java/nextstep/subway/applicaion/PathService.java
+++ b/src/main/java/nextstep/subway/applicaion/PathService.java
@@ -4,27 +4,31 @@ import nextstep.subway.applicaion.dto.PathResponse;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Path;
 import nextstep.subway.domain.Station;
-import nextstep.subway.domain.SubwayMap;
+import nextstep.subway.util.SubwayMap;
+import nextstep.subway.util.SubwayMapFactory;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
 
 @Service
 public class PathService {
-    private LineService lineService;
-    private StationService stationService;
+    private final LineService lineService;
+    private final StationService stationService;
+    private final SubwayMapFactory subwayMapFactory;
 
-    public PathService(LineService lineService, StationService stationService) {
+    public PathService(LineService lineService, StationService stationService, SubwayMapFactory subwayMapFactory) {
         this.lineService = lineService;
         this.stationService = stationService;
+        this.subwayMapFactory = subwayMapFactory;
     }
 
-    public PathResponse findPath(Long source, Long target) {
+    public PathResponse findPath(Long source, Long target, String type) {
         Station upStation = stationService.findById(source);
         Station downStation = stationService.findById(target);
         List<Line> lines = lineService.findLines();
-        SubwayMap subwayMap = new SubwayMap(lines);
-        Path path = subwayMap.findPath(upStation, downStation);
+
+        SubwayMap subwayMap = subwayMapFactory.subwayMap(type);
+        Path path = subwayMap.findPath(lines, upStation, downStation);
 
         return PathResponse.of(path);
     }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
@@ -6,6 +6,7 @@ public class LineRequest {
     private Long upStationId;
     private Long downStationId;
     private int distance;
+    private int duration;
 
     public String getName() {
         return name;
@@ -25,5 +26,9 @@ public class LineRequest {
 
     public int getDistance() {
         return distance;
+    }
+
+    public int getDuration() {
+        return duration;
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/PathResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/PathResponse.java
@@ -8,19 +8,20 @@ import java.util.stream.Collectors;
 public class PathResponse {
     private List<StationResponse> stations;
     private int distance;
+    private int duration;
 
-    public PathResponse(List<StationResponse> stations, int distance) {
+    public PathResponse(List<StationResponse> stations, int distance, int duration) {
         this.stations = stations;
         this.distance = distance;
+        this.duration = duration;
     }
 
     public static PathResponse of(Path path) {
         List<StationResponse> stations = path.getStations().stream()
                 .map(StationResponse::of)
                 .collect(Collectors.toList());
-        int distance = path.extractDistance();
 
-        return new PathResponse(stations, distance);
+        return new PathResponse(stations, path.extractDistance(), path.extractDuration());
     }
 
     public List<StationResponse> getStations() {
@@ -29,5 +30,9 @@ public class PathResponse {
 
     public int getDistance() {
         return distance;
+    }
+
+    public int getDuration() {
+        return duration;
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -4,14 +4,16 @@ public class SectionRequest {
     private Long upStationId;
     private Long downStationId;
     private int distance;
+    private int duration;
 
     public SectionRequest() {
     }
 
-    public SectionRequest(Long upStationId, Long downStationId, int distance) {
+    public SectionRequest(Long upStationId, Long downStationId, int distance, int duration) {
         this.upStationId = upStationId;
         this.downStationId = downStationId;
         this.distance = distance;
+        this.distance = duration;
     }
 
     public Long getUpStationId() {
@@ -24,5 +26,9 @@ public class SectionRequest {
 
     public int getDistance() {
         return distance;
+    }
+
+    public int getDuration() {
+        return duration;
     }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -47,8 +47,8 @@ public class Line {
         }
     }
 
-    public void addSection(Station upStation, Station downStation, int distance) {
-        sections.add(new Section(this, upStation, downStation, distance));
+    public void addSection(Station upStation, Station downStation, int distance, int duration) {
+        sections.add(new Section(this, upStation, downStation, distance, duration));
     }
 
     public List<Station> getStations() {

--- a/src/main/java/nextstep/subway/domain/Path.java
+++ b/src/main/java/nextstep/subway/domain/Path.java
@@ -17,6 +17,10 @@ public class Path {
         return sections.totalDistance();
     }
 
+    public int extractDuration() {
+        return sections.getDuration();
+    }
+
     public List<Station> getStations() {
         return sections.getStations();
     }

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -24,15 +24,18 @@ public class Section extends DefaultWeightedEdge {
 
     private int distance;
 
+    private int duration;
+
     public Section() {
 
     }
 
-    public Section(Line line, Station upStation, Station downStation, int distance) {
+    public Section(Line line, Station upStation, Station downStation, int distance, int duration) {
         this.line = line;
         this.upStation = upStation;
         this.downStation = downStation;
         this.distance = distance;
+        this.duration = duration;
     }
 
     public Long getId() {
@@ -53,6 +56,10 @@ public class Section extends DefaultWeightedEdge {
 
     public int getDistance() {
         return distance;
+    }
+
+    public int getDuration() {
+        return duration;
     }
 
     public boolean isSameUpStation(Station station) {

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -92,7 +92,7 @@ public class Sections {
                 .findFirst()
                 .ifPresent(it -> {
                     // 신규 구간의 상행역과 기존 구간의 상행역에 대한 구간을 추가한다.
-                    sections.add(new Section(section.getLine(), it.getUpStation(), section.getUpStation(), it.getDistance() - section.getDistance()));
+                    sections.add(new Section(section.getLine(), it.getUpStation(), section.getUpStation(), it.getDistance() - section.getDistance(), section.getDuration()));
                     sections.remove(it);
                 });
     }
@@ -103,7 +103,7 @@ public class Sections {
                 .findFirst()
                 .ifPresent(it -> {
                     // 신규 구간의 하행역과 기존 구간의 하행역에 대한 구간을 추가한다.
-                    sections.add(new Section(section.getLine(), section.getDownStation(), it.getDownStation(), it.getDistance() - section.getDistance()));
+                    sections.add(new Section(section.getLine(), section.getDownStation(), it.getDownStation(), it.getDistance() - section.getDistance(), section.getDuration()));
                     sections.remove(it);
                 });
     }
@@ -128,7 +128,8 @@ public class Sections {
                     upSection.get().getLine(),
                     downSection.get().getUpStation(),
                     upSection.get().getDownStation(),
-                    upSection.get().getDistance() + downSection.get().getDistance()
+                    upSection.get().getDistance() + downSection.get().getDistance(),
+                    upSection.get().getDuration() + downSection.get().getDuration()
             );
 
             this.sections.add(newSection);
@@ -149,5 +150,9 @@ public class Sections {
 
     public int totalDistance() {
         return sections.stream().mapToInt(Section::getDistance).sum();
+    }
+
+    public int getDuration() {
+        return sections.stream().mapToInt(Section::getDuration).sum();
     }
 }

--- a/src/main/java/nextstep/subway/domain/Station.java
+++ b/src/main/java/nextstep/subway/domain/Station.java
@@ -19,6 +19,11 @@ public class Station {
         this.name = name;
     }
 
+    public Station(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/nextstep/subway/ui/PathController.java
+++ b/src/main/java/nextstep/subway/ui/PathController.java
@@ -16,7 +16,7 @@ public class PathController {
     }
 
     @GetMapping("/paths")
-    public ResponseEntity<PathResponse> findPath(@RequestParam Long source, @RequestParam Long target) {
-        return ResponseEntity.ok(pathService.findPath(source, target));
+    public ResponseEntity<PathResponse> findPath(@RequestParam Long source, @RequestParam Long target, @RequestParam String type) {
+        return ResponseEntity.ok(pathService.findPath(source, target, type));
     }
 }

--- a/src/main/java/nextstep/subway/util/PathType.java
+++ b/src/main/java/nextstep/subway/util/PathType.java
@@ -1,0 +1,24 @@
+package nextstep.subway.util;
+
+import java.util.Arrays;
+
+public enum PathType {
+    DISTANCE("DISTANCE"), DURATION("DURATION");
+
+    PathType(String name) {
+        this.name = name;
+    }
+
+    private final String name;
+
+    public static PathType find(String pathType) {
+        return Arrays.stream(PathType.values())
+                .filter(provider -> provider.equalsName(pathType))
+                .findAny()
+                .orElseThrow(IllegalArgumentException::new);
+    }
+
+    private boolean equalsName(String pathType) {
+        return this.name.equals(pathType);
+    }
+}

--- a/src/main/java/nextstep/subway/util/ShortestDurationSubwayMap.java
+++ b/src/main/java/nextstep/subway/util/ShortestDurationSubwayMap.java
@@ -1,0 +1,64 @@
+package nextstep.subway.util;
+
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Path;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.SectionEdge;
+import nextstep.subway.domain.Sections;
+import nextstep.subway.domain.Station;
+import org.jgrapht.GraphPath;
+import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
+import org.jgrapht.graph.SimpleDirectedWeightedGraph;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Component
+public class ShortestDurationSubwayMap implements SubwayMap {
+    @Override
+    public PathType pathType() {
+        return PathType.DURATION;
+    }
+
+    @Override
+    public Path findPath(List<Line> lines, Station source, Station target) {
+        SimpleDirectedWeightedGraph<Station, SectionEdge> graph = new SimpleDirectedWeightedGraph<>(SectionEdge.class);
+
+        // 지하철 역(정점)을 등록
+        lines.stream()
+                .flatMap(it -> it.getStations().stream())
+                .distinct()
+                .collect(Collectors.toList())
+                .forEach(graph::addVertex);
+
+        // 지하철 역의 연결 정보(간선)을 등록
+        lines.stream()
+                .flatMap(it -> it.getSections().stream())
+                .forEach(it -> {
+                    SectionEdge sectionEdge = SectionEdge.of(it);
+                    graph.addEdge(it.getUpStation(), it.getDownStation(), sectionEdge);
+                    graph.setEdgeWeight(sectionEdge, it.getDuration());
+                });
+
+        // 지하철 역의 연결 정보(간선)을 등록
+        lines.stream()
+                .flatMap(it -> it.getSections().stream())
+                .map(it -> new Section(it.getLine(), it.getDownStation(), it.getUpStation(), it.getDistance(), it.getDuration()))
+                .forEach(it -> {
+                    SectionEdge sectionEdge = SectionEdge.of(it);
+                    graph.addEdge(it.getUpStation(), it.getDownStation(), sectionEdge);
+                    graph.setEdgeWeight(sectionEdge, it.getDuration());
+                });
+
+        // 다익스트라 최단 경로 찾기
+        DijkstraShortestPath<Station, SectionEdge> dijkstraShortestPath = new DijkstraShortestPath<>(graph);
+        GraphPath<Station, SectionEdge> result = dijkstraShortestPath.getPath(source, target);
+
+        List<Section> sections = result.getEdgeList().stream()
+                .map(SectionEdge::getSection)
+                .collect(Collectors.toList());
+
+        return new Path(new Sections(sections));
+    }
+}

--- a/src/main/java/nextstep/subway/util/SubwayMap.java
+++ b/src/main/java/nextstep/subway/util/SubwayMap.java
@@ -1,0 +1,12 @@
+package nextstep.subway.util;
+
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Path;
+import nextstep.subway.domain.Station;
+
+import java.util.List;
+
+public interface SubwayMap {
+    PathType pathType();
+    Path findPath(List<Line> lines, Station source, Station target);
+}

--- a/src/main/java/nextstep/subway/util/SubwayMapFactory.java
+++ b/src/main/java/nextstep/subway/util/SubwayMapFactory.java
@@ -1,0 +1,24 @@
+package nextstep.subway.util;
+
+import org.springframework.stereotype.Component;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+@Component
+public class SubwayMapFactory {
+    private final Map<PathType, SubwayMap> subwayMaps = new HashMap<>();
+
+    public SubwayMapFactory(Set<SubwayMap> pathFinders) {
+        register(pathFinders);
+    }
+
+    public SubwayMap subwayMap(String pathType) {
+        return subwayMaps.get(PathType.find(pathType));
+    }
+
+    private void register(Set<SubwayMap> pathFinders) {
+        pathFinders.forEach(pathFinder -> subwayMaps.put(pathFinder.pathType(), pathFinder));
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
@@ -17,6 +17,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 경로 검색")
 class PathAcceptanceTest extends AcceptanceTest {
+    private static final String DISTANCE = "DISTANCE";
+    private static final String DURATION = "DURATION";
+
     private Long 교대역;
     private Long 강남역;
     private Long 양재역;
@@ -41,32 +44,46 @@ class PathAcceptanceTest extends AcceptanceTest {
         양재역 = 지하철역_생성_요청(관리자, "양재역").jsonPath().getLong("id");
         남부터미널역 = 지하철역_생성_요청(관리자, "남부터미널역").jsonPath().getLong("id");
 
-        이호선 = 지하철_노선_생성_요청("2호선", "green", 교대역, 강남역, 10);
-        신분당선 = 지하철_노선_생성_요청("신분당선", "red", 강남역, 양재역, 10);
-        삼호선 = 지하철_노선_생성_요청("3호선", "orange", 교대역, 남부터미널역, 2);
+        이호선 = 지하철_노선_생성_요청("2호선", "green", 교대역, 강남역, 10, 4);
+        신분당선 = 지하철_노선_생성_요청("신분당선", "red", 강남역, 양재역, 10, 4);
+        삼호선 = 지하철_노선_생성_요청("3호선", "orange", 교대역, 남부터미널역, 2, 5);
 
-        지하철_노선에_지하철_구간_생성_요청(관리자, 삼호선, createSectionCreateParams(남부터미널역, 양재역, 3));
+        지하철_노선에_지하철_구간_생성_요청(관리자, 삼호선, createSectionCreateParams(남부터미널역, 양재역, 3, 5));
     }
 
     @DisplayName("두 역의 최단 거리 경로를 조회한다.")
     @Test
     void findPathByDistance() {
         // when
-        ExtractableResponse<Response> response = 두_역의_최단_거리_경로_조회를_요청(교대역, 양재역);
+        ExtractableResponse<Response> response = 두_역의_최단_경로_조회를_요청(교대역, 양재역, DISTANCE);
 
         // then
         assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(교대역, 남부터미널역, 양재역);
+        assertThat(response.jsonPath().getInt("distance")).isEqualTo(5);
+        assertThat(response.jsonPath().getInt("duration")).isEqualTo(10);
     }
 
-    private ExtractableResponse<Response> 두_역의_최단_거리_경로_조회를_요청(Long source, Long target) {
+    @DisplayName("두 역의 최단 소요시간 경로를 조회한다.")
+    @Test
+    void findPathByDuration() {
+        // when
+        ExtractableResponse<Response> response = 두_역의_최단_경로_조회를_요청(교대역, 양재역, DURATION);
+
+        // then
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(교대역, 강남역, 양재역);
+        assertThat(response.jsonPath().getInt("distance")).isEqualTo(20);
+        assertThat(response.jsonPath().getInt("duration")).isEqualTo(8);
+    }
+
+    private ExtractableResponse<Response> 두_역의_최단_경로_조회를_요청(Long source, Long target, String type) {
         return RestAssured
                 .given().log().all()
                 .accept(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/paths?source={sourceId}&target={targetId}", source, target)
+                .when().get("/paths?source={sourceId}&target={targetId}&type={type}", source, target, type)
                 .then().log().all().extract();
     }
 
-    private Long 지하철_노선_생성_요청(String name, String color, Long upStation, Long downStation, int distance) {
+    private Long 지하철_노선_생성_요청(String name, String color, Long upStation, Long downStation, int distance, int duration) {
         Map<String, String> lineCreateParams;
         lineCreateParams = new HashMap<>();
         lineCreateParams.put("name", name);
@@ -74,15 +91,17 @@ class PathAcceptanceTest extends AcceptanceTest {
         lineCreateParams.put("upStationId", upStation + "");
         lineCreateParams.put("downStationId", downStation + "");
         lineCreateParams.put("distance", distance + "");
+        lineCreateParams.put("duration", duration + "");
 
         return LineSteps.지하철_노선_생성_요청(관리자, lineCreateParams).jsonPath().getLong("id");
     }
 
-    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId, int distance) {
+    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId, int distance, int duration) {
         Map<String, String> params = new HashMap<>();
         params.put("upStationId", upStationId + "");
         params.put("downStationId", downStationId + "");
         params.put("distance", distance + "");
+        params.put("duration", duration + "");
         return params;
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
@@ -51,6 +51,17 @@ class PathAcceptanceTest extends AcceptanceTest {
         지하철_노선에_지하철_구간_생성_요청(관리자, 삼호선, createSectionCreateParams(남부터미널역, 양재역, 3, 5));
     }
 
+    /**
+     * Feature: 지하철 경로 검색
+     *
+     *   Scenario: 두 역의 최소 시간 경로를 조회
+     *     Given 지하철역이 등록되어있음
+     *     And 지하철 노선이 등록되어있음
+     *     And 지하철 노선에 지하철역이 등록되어있음
+     *     When 출발역에서 도착역까지의 최단 거리 기준으로 경로 조회를 요청
+     *     Then 최소 시간 기준 경로를 응답
+     *     And 총 거리와 소요 시간을 함께 응답함
+     */
     @DisplayName("두 역의 최단 거리 경로를 조회한다.")
     @Test
     void findPathByDistance() {
@@ -63,6 +74,17 @@ class PathAcceptanceTest extends AcceptanceTest {
         assertThat(response.jsonPath().getInt("duration")).isEqualTo(10);
     }
 
+    /**
+     * Feature: 지하철 경로 검색
+     *
+     *   Scenario: 두 역의 최소 시간 경로를 조회
+     *     Given 지하철역이 등록되어있음
+     *     And 지하철 노선이 등록되어있음
+     *     And 지하철 노선에 지하철역이 등록되어있음
+     *     When 출발역에서 도착역까지의 최소 시간 기준으로 경로 조회를 요청
+     *     Then 최소 시간 기준 경로를 응답
+     *     And 총 거리와 소요 시간을 함께 응답함
+     */
     @DisplayName("두 역의 최단 소요시간 경로를 조회한다.")
     @Test
     void findPathByDuration() {

--- a/src/test/java/nextstep/subway/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/documentation/PathDocumentation.java
@@ -1,19 +1,61 @@
 package nextstep.subway.documentation;
 
 import io.restassured.RestAssured;
+import nextstep.subway.applicaion.PathService;
+import nextstep.subway.applicaion.dto.PathResponse;
+import nextstep.subway.applicaion.dto.StationResponse;
+import nextstep.subway.domain.Station;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 
-public class PathDocumentation extends Documentation {
+import java.util.List;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
+
+class PathDocumentation extends Documentation {
+
+    @MockBean
+    private PathService pathService;
 
     @Test
     void path() {
+        when(pathService.findPath(1L, 2L, "DISTANCE")).thenReturn(경로_생성());
+
         RestAssured
-                .given().log().all()
+                .given(spec).log().all()
+                .filter(document("paths",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestParameters(
+                                parameterWithName("source").description("출발역 ID"),
+                                parameterWithName("target").description("도착역 ID"),
+                                parameterWithName("type").description("경로를 구하는 기준(거리/소요시간)")),
+                        responseFields(
+                                subsectionWithPath("stations.[].id").description("지하철역 ID"),
+                                subsectionWithPath("stations.[].name").description("지하철역 이름"),
+                                subsectionWithPath("distance").description("거리"),
+                                subsectionWithPath("duration").description("소요시간"))
+                ))
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .queryParam("source", 1L)
                 .queryParam("target", 2L)
+                .queryParam("type", "DISTANCE")
                 .when().get("/paths")
                 .then().log().all().extract();
+    }
+
+    private PathResponse 경로_생성() {
+        List<StationResponse> 지하철역_목록 = List.of(
+                StationResponse.of(new Station(1L, "교대역")),
+                StationResponse.of(new Station(3L, "강남역")),
+                StationResponse.of(new Station(2L, "잠실역")));
+
+        return new PathResponse(지하철역_목록, 20, 10);
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -44,7 +44,7 @@ class LineServiceMockTest {
         삼성역 = new Station("삼성역");
         ReflectionTestUtils.setField(삼성역, "id", 3L);
         이호선 = new Line("2호선", "green");
-        이호선.addSection(강남역, 역삼역, 10);
+        이호선.addSection(강남역, 역삼역, 10, 10);
         ReflectionTestUtils.setField(이호선, "id", 1L);
     }
 
@@ -54,7 +54,7 @@ class LineServiceMockTest {
         when(stationService.findById(역삼역.getId())).thenReturn(역삼역);
         when(stationService.findById(삼성역.getId())).thenReturn(삼성역);
 
-        lineService.addSection(이호선.getId(), new SectionRequest(역삼역.getId(), 삼성역.getId(), 10));
+        lineService.addSection(이호선.getId(), new SectionRequest(역삼역.getId(), 삼성역.getId(), 10, 10));
 
         Line line = lineService.findById(1L);
 

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -31,7 +31,7 @@ class LineServiceTest {
         Station 삼성역 = stationRepository.save(new Station("삼성역"));
         Line 이호선 = lineRepository.save(createLine(강남역, 역삼역));
 
-        lineService.addSection(이호선.getId(), new SectionRequest(역삼역.getId(), 삼성역.getId(), 10));
+        lineService.addSection(이호선.getId(), new SectionRequest(역삼역.getId(), 삼성역.getId(), 10, 10));
 
         Line line = lineService.findById(이호선.getId());
 
@@ -40,7 +40,7 @@ class LineServiceTest {
 
     private Line createLine(Station 강남역, Station 역삼역) {
         Line line = new Line("2호선", "green");
-        line.addSection(강남역, 역삼역, 10);
+        line.addSection(강남역, 역삼역, 10, 10);
         return line;
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -19,8 +19,8 @@ class LineTest {
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
 
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(역삼역, 삼성역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(역삼역, 삼성역, 5, 5);
 
         assertThat(line.getStations()).containsExactly(강남역, 역삼역, 삼성역);
     }
@@ -33,8 +33,8 @@ class LineTest {
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
 
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(강남역, 삼성역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(강남역, 삼성역, 5, 5);
 
         assertThat(line.getSections().size()).isEqualTo(2);
         Section section = line.getSections().stream()
@@ -52,8 +52,8 @@ class LineTest {
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
 
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(삼성역, 역삼역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(삼성역, 역삼역, 5, 5);
 
         assertThat(line.getSections().size()).isEqualTo(2);
         Section section = line.getSections().stream()
@@ -71,8 +71,8 @@ class LineTest {
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
 
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(삼성역, 강남역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(삼성역, 강남역, 5, 5);
 
         assertThat(line.getSections().size()).isEqualTo(2);
         Section section = line.getSections().stream()
@@ -90,8 +90,8 @@ class LineTest {
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
 
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(역삼역, 삼성역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(역삼역, 삼성역, 5, 5);
 
         assertThat(line.getSections().size()).isEqualTo(2);
         Section section = line.getSections().stream()
@@ -107,8 +107,8 @@ class LineTest {
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(강남역, 삼성역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(강남역, 삼성역, 5, 5);
 
         List<Station> result = line.getStations();
 
@@ -121,9 +121,9 @@ class LineTest {
         Station 강남역 = new Station("강남역");
         Station 역삼역 = new Station("역삼역");
         Line line = new Line("2호선", "green");
-        line.addSection(강남역, 역삼역, 10);
+        line.addSection(강남역, 역삼역, 10, 10);
 
-        assertThatThrownBy(() -> line.addSection(강남역, 역삼역, 5))
+        assertThatThrownBy(() -> line.addSection(강남역, 역삼역, 5, 5))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -133,8 +133,8 @@ class LineTest {
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(역삼역, 삼성역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(역삼역, 삼성역, 5, 5);
 
         line.deleteSection(삼성역);
 
@@ -147,8 +147,8 @@ class LineTest {
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(역삼역, 삼성역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(역삼역, 삼성역, 5, 5);
 
         line.deleteSection(강남역);
 
@@ -161,8 +161,8 @@ class LineTest {
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(역삼역, 삼성역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(역삼역, 삼성역, 5, 5);
 
         line.deleteSection(역삼역);
 
@@ -175,7 +175,7 @@ class LineTest {
         Station 강남역 = new Station("강남역");
         Station 역삼역 = new Station("역삼역");
         Line line = new Line("2호선", "green");
-        line.addSection(강남역, 역삼역, 10);
+        line.addSection(강남역, 역삼역, 10, 10);
 
         assertThatThrownBy(() -> line.deleteSection(역삼역))
                 .isInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/nextstep/subway/util/PathTypeTest.java
+++ b/src/test/java/nextstep/subway/util/PathTypeTest.java
@@ -1,0 +1,25 @@
+package nextstep.subway.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class PathTypeTest {
+    @DisplayName("이름에 맞는 타입을 찾아 반환한다.")
+    @CsvSource(value = {"DISTANCE:DISTANCE", "DURATION:DURATION"}, delimiter = ':')
+    @ParameterizedTest
+    void find(String type, PathType pathType) {
+        assertThat(PathType.find(type)).isEqualTo(pathType);
+    }
+
+    @DisplayName("존재하지 않는 타입을 찾을 경우 예외를 발생시킨다.")
+    @Test
+    void findNonExistentPathType() {
+        assertThatThrownBy(() -> PathType.find("example"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}

--- a/src/test/java/nextstep/subway/util/ShortestDistanceSubwayMapTest.java
+++ b/src/test/java/nextstep/subway/util/ShortestDistanceSubwayMapTest.java
@@ -1,11 +1,11 @@
-package nextstep.subway.unit;
+package nextstep.subway.util;
 
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Path;
 import nextstep.subway.domain.Station;
-import nextstep.subway.domain.SubwayMap;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -13,8 +13,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class SubwayMapTest {
-
+class ShortestDistanceSubwayMapTest {
     private Station 교대역;
     private Station 강남역;
     private Station 양재역;
@@ -34,33 +33,35 @@ public class SubwayMapTest {
         이호선 = new Line("2호선", "red");
         삼호선 = new Line("3호선", "red");
 
-        신분당선.addSection(강남역, 양재역, 3);
-        이호선.addSection(교대역, 강남역, 3);
-        삼호선.addSection(교대역, 남부터미널역, 5);
-        삼호선.addSection(남부터미널역, 양재역, 5);
+        신분당선.addSection(강남역, 양재역, 3, 10);
+        이호선.addSection(교대역, 강남역, 3, 10);
+        삼호선.addSection(교대역, 남부터미널역, 5, 1);
+        삼호선.addSection(남부터미널역, 양재역, 5, 1);
     }
 
+    @DisplayName("최단거리 경로를 조회한다.")
     @Test
     void findPath() {
         // given
         List<Line> lines = Lists.newArrayList(신분당선, 이호선, 삼호선);
-        SubwayMap subwayMap = new SubwayMap(lines);
+        ShortestDistanceSubwayMap subwayMap = new ShortestDistanceSubwayMap();
 
         // when
-        Path path = subwayMap.findPath(교대역, 양재역);
+        Path path = subwayMap.findPath(lines, 교대역, 양재역);
 
         // then
         assertThat(path.getStations()).containsExactlyElementsOf(Lists.newArrayList(교대역, 강남역, 양재역));
     }
 
+    @DisplayName("최단거리 경로를 조회한다.(반대 방향)")
     @Test
     void findPathOppositely() {
         // given
         List<Line> lines = Lists.newArrayList(신분당선, 이호선, 삼호선);
-        SubwayMap subwayMap = new SubwayMap(lines);
+        ShortestDistanceSubwayMap subwayMap = new ShortestDistanceSubwayMap();
 
         // when
-        Path path = subwayMap.findPath(양재역, 교대역);
+        Path path = subwayMap.findPath(lines, 양재역, 교대역);
 
         // then
         assertThat(path.getStations()).containsExactlyElementsOf(Lists.newArrayList(양재역, 강남역, 교대역));

--- a/src/test/java/nextstep/subway/util/ShortestDurationSubwayMapTest.java
+++ b/src/test/java/nextstep/subway/util/ShortestDurationSubwayMapTest.java
@@ -1,0 +1,76 @@
+package nextstep.subway.util;
+
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Path;
+import nextstep.subway.domain.Station;
+import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class ShortestDurationSubwayMapTest {
+    private Station 교대역;
+    private Station 강남역;
+    private Station 양재역;
+    private Station 남부터미널역;
+    private Line 신분당선;
+    private Line 이호선;
+    private Line 삼호선;
+
+    @BeforeEach
+    void setUp() {
+        교대역 = createStation(1L, "교대역");
+        강남역 = createStation(2L, "강남역");
+        양재역 = createStation(3L, "양재역");
+        남부터미널역 = createStation(4L, "남부터미널역");
+
+        신분당선 = new Line("신분당선", "red");
+        이호선 = new Line("2호선", "red");
+        삼호선 = new Line("3호선", "red");
+
+        신분당선.addSection(강남역, 양재역, 3, 10);
+        이호선.addSection(교대역, 강남역, 3, 10);
+        삼호선.addSection(교대역, 남부터미널역, 5, 1);
+        삼호선.addSection(남부터미널역, 양재역, 5, 1);
+    }
+
+    @DisplayName("최소 소요시간 경로를 조회한다.")
+    @Test
+    void findPath() {
+        // given
+        List<Line> lines = Lists.newArrayList(신분당선, 이호선, 삼호선);
+        ShortestDurationSubwayMap subwayMap = new ShortestDurationSubwayMap();
+
+        // when
+        Path path = subwayMap.findPath(lines, 교대역, 양재역);
+
+        // then
+        assertThat(path.getStations()).containsExactlyElementsOf(Lists.newArrayList(교대역, 남부터미널역, 양재역));
+    }
+
+    @DisplayName("최소 소요시간 경로를 조회한다.(반대 방향)")
+    @Test
+    void findPathOppositely() {
+        // given
+        List<Line> lines = Lists.newArrayList(신분당선, 이호선, 삼호선);
+        ShortestDurationSubwayMap subwayMap = new ShortestDurationSubwayMap();
+
+        // when
+        Path path = subwayMap.findPath(lines, 양재역, 교대역);
+
+        // then
+        assertThat(path.getStations()).containsExactlyElementsOf(Lists.newArrayList(양재역, 남부터미널역, 교대역));
+    }
+
+    private Station createStation(long id, String name) {
+        Station station = new Station(name);
+        ReflectionTestUtils.setField(station, "id", id);
+
+        return station;
+    }
+}

--- a/src/test/java/nextstep/subway/util/SubwayMapFactoryTest.java
+++ b/src/test/java/nextstep/subway/util/SubwayMapFactoryTest.java
@@ -1,0 +1,42 @@
+package nextstep.subway.util;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+
+class SubwayMapFactoryTest {
+
+    private SubwayMapFactory subwayMapFactory;
+
+    @BeforeEach
+    void init() {
+        HashSet<SubwayMap> subwayMaps = new HashSet<>(List.of(new ShortestDistanceSubwayMap(), new ShortestDurationSubwayMap()));
+        subwayMapFactory = new SubwayMapFactory(subwayMaps);
+    }
+
+    @DisplayName("타입에 맞는 SubwayMap을 반환한다.")
+    @Test
+    void subwayMap() {
+        SubwayMap distance = subwayMapFactory.subwayMap("DISTANCE");
+        SubwayMap duration = subwayMapFactory.subwayMap("DURATION");
+
+        assertAll(
+                () -> assertThat(distance).isInstanceOf(ShortestDistanceSubwayMap.class),
+                () -> assertThat(duration).isInstanceOf(ShortestDurationSubwayMap.class)
+        );
+    }
+
+    @DisplayName("존재하지 않는 타입의 SubwayMap을 요청할 경우 예외를 발생시킨다.")
+    @Test
+    void subwayMapNonExistentType() {
+        assertThatThrownBy(() -> subwayMapFactory.subwayMap("EXAMPLE"))
+                .isInstanceOf(IllegalArgumentException.class);
+    }
+}


### PR DESCRIPTION
안녕하세요 영철님! 1단계 미션 완료했습니다.
경로 조회 타입에 따라 최단 경로를 찾는 방식이 다른데, 전략 패턴을 사용하여 아래 사진과 같이 PathServie가 구체 클래스가 아닌 SubwayMap 인터페이스에 의존하도록 했습니다.
<img width="664" alt="전략패턴" src="https://user-images.githubusercontent.com/49121847/184506346-ca7af7c6-b77d-4cc7-ad06-df0edf9711aa.png">
또한 최단 경로를 찾아주는 SubwayMap이 유틸 클래스의 성격을 가진다고 생각하여 util 패키지로 분리했습니다.
잘 부탁드립니다 🙂