### PR TITLE
경로 조회 타입 추가 미션

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -11,4 +11,4 @@
 
 === 경로 조회
 
-operation::path[snippets='http-request,http-response']
+operation::path[snippets='http-request,request-parameters,http-response,response-fields']

--- a/src/main/java/nextstep/subway/WebConfig.java
+++ b/src/main/java/nextstep/subway/WebConfig.java
@@ -1,0 +1,15 @@
+package nextstep.subway;
+
+import nextstep.subway.ui.SearchTypeRequestConverter;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new SearchTypeRequestConverter());
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -30,7 +30,7 @@ public class LineService {
         if (request.getUpStationId() != null && request.getDownStationId() != null && request.getDistance() != 0) {
             Station upStation = stationService.findById(request.getUpStationId());
             Station downStation = stationService.findById(request.getDownStationId());
-            line.addSection(upStation, downStation, request.getDistance());
+            line.addSection(upStation, downStation, request.getDistance(), request.getDuration());
         }
         return LineResponse.of(line);
     }
@@ -70,7 +70,7 @@ public class LineService {
         Station downStation = stationService.findById(sectionRequest.getDownStationId());
         Line line = findById(lineId);
 
-        line.addSection(upStation, downStation, sectionRequest.getDistance());
+        line.addSection(upStation, downStation, sectionRequest.getDistance(), sectionRequest.getDuration());
     }
 
     private List<StationResponse> createStationResponses(Line line) {

--- a/src/main/java/nextstep/subway/applicaion/PathService.java
+++ b/src/main/java/nextstep/subway/applicaion/PathService.java
@@ -7,7 +7,6 @@ import nextstep.subway.domain.SearchType;
 import nextstep.subway.domain.Station;
 import nextstep.subway.domain.SubwayMap;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 

--- a/src/main/java/nextstep/subway/applicaion/PathService.java
+++ b/src/main/java/nextstep/subway/applicaion/PathService.java
@@ -3,6 +3,7 @@ package nextstep.subway.applicaion;
 import nextstep.subway.applicaion.dto.PathResponse;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Path;
+import nextstep.subway.domain.SearchType;
 import nextstep.subway.domain.Station;
 import nextstep.subway.domain.SubwayMap;
 import org.springframework.stereotype.Service;
@@ -19,11 +20,13 @@ public class PathService {
         this.stationService = stationService;
     }
 
-    public PathResponse findPath(Long source, Long target) {
+    public PathResponse findPath(Long source, Long target, SearchType type) {
         Station upStation = stationService.findById(source);
         Station downStation = stationService.findById(target);
         List<Line> lines = lineService.findLines();
         SubwayMap subwayMap = new SubwayMap(lines);
+
+        // TODO: 경로 조회 기준 [DISTANCE, DURATION] 에 따라서 경로를 탐색한다
         Path path = subwayMap.findPath(upStation, downStation);
 
         return PathResponse.of(path);

--- a/src/main/java/nextstep/subway/applicaion/PathService.java
+++ b/src/main/java/nextstep/subway/applicaion/PathService.java
@@ -7,6 +7,7 @@ import nextstep.subway.domain.SearchType;
 import nextstep.subway.domain.Station;
 import nextstep.subway.domain.SubwayMap;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -20,14 +21,13 @@ public class PathService {
         this.stationService = stationService;
     }
 
-    public PathResponse findPath(Long source, Long target, SearchType type) {
-        Station upStation = stationService.findById(source);
-        Station downStation = stationService.findById(target);
+    public PathResponse findPath(Long source, Long target, SearchType searchType) {
+        Station departureStation = stationService.findById(source);
+        Station destinationStation = stationService.findById(target);
         List<Line> lines = lineService.findLines();
-        SubwayMap subwayMap = new SubwayMap(lines);
 
-        // TODO: 경로 조회 기준 [DISTANCE, DURATION] 에 따라서 경로를 탐색한다
-        Path path = subwayMap.findPath(upStation, downStation);
+        SubwayMap subwayMap = new SubwayMap(lines, searchType);
+        Path path = subwayMap.findPath(departureStation, destinationStation);
 
         return PathResponse.of(path);
     }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
@@ -7,6 +7,8 @@ public class LineRequest {
     private Long downStationId;
     private int distance;
 
+    private int duration;
+
     public String getName() {
         return name;
     }
@@ -25,5 +27,9 @@ public class LineRequest {
 
     public int getDistance() {
         return distance;
+    }
+
+    public int getDuration() {
+        return duration;
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/PathResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/PathResponse.java
@@ -8,10 +8,12 @@ import java.util.stream.Collectors;
 public class PathResponse {
     private List<StationResponse> stations;
     private int distance;
+    private int duration;
 
-    public PathResponse(List<StationResponse> stations, int distance) {
+    public PathResponse(List<StationResponse> stations, int distance, int duration) {
         this.stations = stations;
         this.distance = distance;
+        this.duration = duration;
     }
 
     public static PathResponse of(Path path) {
@@ -19,8 +21,9 @@ public class PathResponse {
                 .map(StationResponse::of)
                 .collect(Collectors.toList());
         int distance = path.extractDistance();
+        int duration = path.extractDuration();
 
-        return new PathResponse(stations, distance);
+        return new PathResponse(stations, distance, duration);
     }
 
     public List<StationResponse> getStations() {
@@ -29,5 +32,9 @@ public class PathResponse {
 
     public int getDistance() {
         return distance;
+    }
+
+    public int getDuration() {
+        return duration;
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/SectionRequest.java
@@ -4,14 +4,16 @@ public class SectionRequest {
     private Long upStationId;
     private Long downStationId;
     private int distance;
+    private int duration;
 
     public SectionRequest() {
     }
 
-    public SectionRequest(Long upStationId, Long downStationId, int distance) {
+    public SectionRequest(Long upStationId, Long downStationId, int distance, int duration) {
         this.upStationId = upStationId;
         this.downStationId = downStationId;
         this.distance = distance;
+        this.duration = duration;
     }
 
     public Long getUpStationId() {
@@ -24,5 +26,9 @@ public class SectionRequest {
 
     public int getDistance() {
         return distance;
+    }
+
+    public int getDuration() {
+        return duration;
     }
 }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -51,8 +51,8 @@ public class Line {
         }
     }
 
-    public void addSection(Station upStation, Station downStation, int distance) {
-        sections.add(new Section(this, upStation, downStation, distance));
+    public void addSection(Station upStation, Station downStation, int distance, int duration) {
+        sections.add(new Section(this, upStation, downStation, distance, duration));
     }
 
     public List<Station> getStations() {

--- a/src/main/java/nextstep/subway/domain/Path.java
+++ b/src/main/java/nextstep/subway/domain/Path.java
@@ -17,6 +17,10 @@ public class Path {
         return sections.totalDistance();
     }
 
+    public int extractDuration() {
+        return sections.totalDuration();
+    }
+
     public List<Station> getStations() {
         return sections.getStations();
     }

--- a/src/main/java/nextstep/subway/domain/SearchType.java
+++ b/src/main/java/nextstep/subway/domain/SearchType.java
@@ -3,4 +3,13 @@ package nextstep.subway.domain;
 public enum SearchType {
     DISTANCE,
     DURATION,
+    ;
+
+    public boolean isDistance() {
+        return this.equals(DISTANCE);
+    }
+
+    public boolean isDuration() {
+        return this.equals(DURATION);
+    }
 }

--- a/src/main/java/nextstep/subway/domain/SearchType.java
+++ b/src/main/java/nextstep/subway/domain/SearchType.java
@@ -1,0 +1,6 @@
+package nextstep.subway.domain;
+
+public enum SearchType {
+    DISTANCE,
+    DURATION,
+}

--- a/src/main/java/nextstep/subway/domain/Section.java
+++ b/src/main/java/nextstep/subway/domain/Section.java
@@ -30,15 +30,17 @@ public class Section extends DefaultWeightedEdge {
 
     private int distance;
 
-    public Section() {
+    private int duration;
 
+    protected Section() {
     }
 
-    public Section(Line line, Station upStation, Station downStation, int distance) {
+    public Section(Line line, Station upStation, Station downStation, int distance, int duration) {
         this.line = line;
         this.upStation = upStation;
         this.downStation = downStation;
         this.distance = distance;
+        this.duration = duration;
     }
 
     public Long getId() {
@@ -59,6 +61,10 @@ public class Section extends DefaultWeightedEdge {
 
     public int getDistance() {
         return distance;
+    }
+
+    public int getDuration() {
+        return duration;
     }
 
     public boolean isSameUpStation(Station station) {

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -14,7 +14,7 @@ public class Sections {
     @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
     private List<Section> sections = new ArrayList<>();
 
-    public Sections() {
+    protected Sections() {
     }
 
     public Sections(List<Section> sections) {
@@ -92,7 +92,15 @@ public class Sections {
                 .findFirst()
                 .ifPresent(it -> {
                     // 신규 구간의 상행역과 기존 구간의 상행역에 대한 구간을 추가한다.
-                    sections.add(new Section(section.getLine(), it.getUpStation(), section.getUpStation(), it.getDistance() - section.getDistance()));
+                    sections.add(
+                            new Section(
+                                    section.getLine(),
+                                    it.getUpStation(),
+                                    section.getUpStation(),
+                                    it.getDistance() - section.getDistance(),
+                                    it.getDuration() - section.getDuration()
+                            )
+                    );
                     sections.remove(it);
                 });
     }
@@ -103,7 +111,15 @@ public class Sections {
                 .findFirst()
                 .ifPresent(it -> {
                     // 신규 구간의 하행역과 기존 구간의 하행역에 대한 구간을 추가한다.
-                    sections.add(new Section(section.getLine(), section.getDownStation(), it.getDownStation(), it.getDistance() - section.getDistance()));
+                    sections.add(
+                            new Section(
+                                    section.getLine(),
+                                    section.getDownStation(),
+                                    it.getDownStation(),
+                                    it.getDistance() - section.getDistance(),
+                                    it.getDuration() - section.getDuration()
+                            )
+                    );
                     sections.remove(it);
                 });
     }
@@ -128,7 +144,8 @@ public class Sections {
                     upSection.get().getLine(),
                     downSection.get().getUpStation(),
                     upSection.get().getDownStation(),
-                    upSection.get().getDistance() + downSection.get().getDistance()
+                    upSection.get().getDistance() + downSection.get().getDistance(),
+                    upSection.get().getDuration() + downSection.get().getDuration()
             );
 
             this.sections.add(newSection);

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -167,4 +167,8 @@ public class Sections {
     public int totalDistance() {
         return sections.stream().mapToInt(Section::getDistance).sum();
     }
+
+    public int totalDuration() {
+        return sections.stream().mapToInt(Section::getDuration).sum();
+    }
 }

--- a/src/main/java/nextstep/subway/domain/SubwayMap.java
+++ b/src/main/java/nextstep/subway/domain/SubwayMap.java
@@ -36,7 +36,7 @@ public class SubwayMap {
         // 지하철 역의 연결 정보(간선)을 등록
         lines.stream()
                 .flatMap(it -> it.getSections().stream())
-                .map(it -> new Section(it.getLine(), it.getDownStation(), it.getUpStation(), it.getDistance()))
+                .map(it -> new Section(it.getLine(), it.getDownStation(), it.getUpStation(), it.getDistance(), it.getDuration()))
                 .forEach(it -> {
                     SectionEdge sectionEdge = SectionEdge.of(it);
                     graph.addEdge(it.getUpStation(), it.getDownStation(), sectionEdge);

--- a/src/main/java/nextstep/subway/domain/SubwayMap.java
+++ b/src/main/java/nextstep/subway/domain/SubwayMap.java
@@ -8,49 +8,86 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class SubwayMap {
-    private List<Line> lines;
+    private final List<Line> lines;
+    private final SearchType searchType;
+    private final SimpleDirectedWeightedGraph<Station, SectionEdge> graph;
 
-    public SubwayMap(List<Line> lines) {
+    public SubwayMap(List<Line> lines, SearchType searchType) {
         this.lines = lines;
+        this.searchType = searchType;
+        this.graph = createGraph();
     }
 
+    /**
+     * 다익스트라 알고리즘을 이용한 최소 가중치의 경로 찾기
+     */
     public Path findPath(Station source, Station target) {
-        SimpleDirectedWeightedGraph<Station, SectionEdge> graph = new SimpleDirectedWeightedGraph<>(SectionEdge.class);
-
-        // 지하철 역(정점)을 등록
-        lines.stream()
-                .flatMap(it -> it.getStations().stream())
-                .distinct()
-                .collect(Collectors.toList())
-                .forEach(it -> graph.addVertex(it));
-
-        // 지하철 역의 연결 정보(간선)을 등록
-        lines.stream()
-                .flatMap(it -> it.getSections().stream())
-                .forEach(it -> {
-                    SectionEdge sectionEdge = SectionEdge.of(it);
-                    graph.addEdge(it.getUpStation(), it.getDownStation(), sectionEdge);
-                    graph.setEdgeWeight(sectionEdge, it.getDistance());
-                });
-
-        // 지하철 역의 연결 정보(간선)을 등록
-        lines.stream()
-                .flatMap(it -> it.getSections().stream())
-                .map(it -> new Section(it.getLine(), it.getDownStation(), it.getUpStation(), it.getDistance(), it.getDuration()))
-                .forEach(it -> {
-                    SectionEdge sectionEdge = SectionEdge.of(it);
-                    graph.addEdge(it.getUpStation(), it.getDownStation(), sectionEdge);
-                    graph.setEdgeWeight(sectionEdge, it.getDistance());
-                });
-
-        // 다익스트라 최단 경로 찾기
         DijkstraShortestPath<Station, SectionEdge> dijkstraShortestPath = new DijkstraShortestPath<>(graph);
         GraphPath<Station, SectionEdge> result = dijkstraShortestPath.getPath(source, target);
 
         List<Section> sections = result.getEdgeList().stream()
-                .map(it -> it.getSection())
+                .map(SectionEdge::getSection)
                 .collect(Collectors.toList());
 
         return new Path(new Sections(sections));
+    }
+
+    private SimpleDirectedWeightedGraph<Station, SectionEdge> createGraph() {
+        SimpleDirectedWeightedGraph<Station, SectionEdge> graph = new SimpleDirectedWeightedGraph<>(SectionEdge.class);
+
+        addVertex(graph);
+        addEdge(graph);
+        addEdgeForOppositePath(graph);
+
+        return graph;
+    }
+
+    /**
+     * 지하철 역(정점)을 등록
+     */
+    private void addVertex(SimpleDirectedWeightedGraph<Station, SectionEdge> graph) {
+        lines.stream()
+                .flatMap(it -> it.getStations().stream())
+                .distinct()
+                .collect(Collectors.toList())
+                .forEach(graph::addVertex);
+    }
+
+    /**
+     * 지하철 역의 연결 정보(간선)을 등록
+     */
+    private void addEdge(SimpleDirectedWeightedGraph<Station, SectionEdge> graph) {
+        lines.stream()
+                .flatMap(it -> it.getSections().stream())
+                .forEach(it -> {
+                    SectionEdge sectionEdge = SectionEdge.of(it);
+                    graph.addEdge(it.getUpStation(), it.getDownStation(), sectionEdge);
+                    graph.setEdgeWeight(sectionEdge, getWeight(it));
+                });
+    }
+
+    /**
+     * 지하철 역의 연결 정보(간선)을 등록
+     */
+    private void addEdgeForOppositePath(SimpleDirectedWeightedGraph<Station, SectionEdge> graph) {
+        lines.stream()
+                .flatMap(it -> it.getSections().stream())
+                .map(it -> new Section(it.getLine(), it.getDownStation(), it.getUpStation(), getWeight(it), it.getDuration()))
+                .forEach(it -> {
+                    SectionEdge sectionEdge = SectionEdge.of(it);
+                    graph.addEdge(it.getUpStation(), it.getDownStation(), sectionEdge);
+                    graph.setEdgeWeight(sectionEdge, getWeight(it));
+                });
+    }
+
+    private int getWeight(Section section) {
+        if (searchType.isDistance()) {
+            return section.getDistance();
+        }
+        if (searchType.isDuration()) {
+            return section.getDistance();
+        }
+
+        throw new RuntimeException();
     }
 }

--- a/src/main/java/nextstep/subway/ui/PathController.java
+++ b/src/main/java/nextstep/subway/ui/PathController.java
@@ -2,6 +2,7 @@ package nextstep.subway.ui;
 
 import nextstep.subway.applicaion.PathService;
 import nextstep.subway.applicaion.dto.PathResponse;
+import nextstep.subway.domain.SearchType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -16,7 +17,7 @@ public class PathController {
     }
 
     @GetMapping("/paths")
-    public ResponseEntity<PathResponse> findPath(@RequestParam Long source, @RequestParam Long target) {
-        return ResponseEntity.ok(pathService.findPath(source, target));
+    public ResponseEntity<PathResponse> findPath(@RequestParam Long source, @RequestParam Long target, @RequestParam SearchType type) {
+        return ResponseEntity.ok(pathService.findPath(source, target, type));
     }
 }

--- a/src/main/java/nextstep/subway/ui/SearchTypeRequestConverter.java
+++ b/src/main/java/nextstep/subway/ui/SearchTypeRequestConverter.java
@@ -1,0 +1,12 @@
+package nextstep.subway.ui;
+
+import nextstep.subway.domain.SearchType;
+import org.springframework.core.convert.converter.Converter;
+
+public class SearchTypeRequestConverter implements Converter<String, SearchType> {
+
+    @Override
+    public SearchType convert(String type) {
+        return SearchType.valueOf(type);
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FavoriteAcceptanceTest.java
@@ -49,11 +49,11 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
         양재역 = 지하철역_생성_요청(관리자, "양재역").jsonPath().getLong("id");
         남부터미널역 = 지하철역_생성_요청(관리자, "남부터미널역").jsonPath().getLong("id");
 
-        이호선 = 지하철_노선_생성_요청("2호선", "green", 교대역, 강남역, 10);
-        신분당선 = 지하철_노선_생성_요청("신분당선", "red", 강남역, 양재역, 10);
-        삼호선 = 지하철_노선_생성_요청("3호선", "orange", 교대역, 남부터미널역, 2);
+        이호선 = 지하철_노선_생성_요청("2호선", "green", 교대역, 강남역, 10, 10);
+        신분당선 = 지하철_노선_생성_요청("신분당선", "red", 강남역, 양재역, 10, 10);
+        삼호선 = 지하철_노선_생성_요청("3호선", "orange", 교대역, 남부터미널역, 2, 2);
 
-        지하철_노선에_지하철_구간_생성_요청(관리자, 삼호선, createSectionCreateParams(남부터미널역, 양재역, 3));
+        지하철_노선에_지하철_구간_생성_요청(관리자, 삼호선, createSectionCreateParams(남부터미널역, 양재역, 3, 3));
 
         사용자 = 베어러_인증_로그인_요청(EMAIL, PASSWORD).jsonPath().getString("accessToken");
     }
@@ -77,7 +77,7 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
         즐겨찾기_삭제됨(deleteResponse);
     }
 
-    private Long 지하철_노선_생성_요청(String name, String color, Long upStation, Long downStation, int distance) {
+    private Long 지하철_노선_생성_요청(String name, String color, Long upStation, Long downStation, int distance, int duration) {
         Map<String, String> lineCreateParams;
         lineCreateParams = new HashMap<>();
         lineCreateParams.put("name", name);
@@ -85,15 +85,17 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
         lineCreateParams.put("upStationId", upStation + "");
         lineCreateParams.put("downStationId", downStation + "");
         lineCreateParams.put("distance", distance + "");
+        lineCreateParams.put("duration", duration + "");
 
         return LineSteps.지하철_노선_생성_요청(관리자, lineCreateParams).jsonPath().getLong("id");
     }
 
-    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId, int distance) {
+    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId, int distance, int duration) {
         Map<String, String> params = new HashMap<>();
         params.put("upStationId", upStationId + "");
         params.put("downStationId", downStationId + "");
         params.put("distance", distance + "");
+        params.put("duration", duration + "");
         return params;
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSectionAcceptanceTest.java
@@ -136,6 +136,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         lineCreateParams.put("upStationId", upStationId + "");
         lineCreateParams.put("downStationId", downStationId + "");
         lineCreateParams.put("distance", 10 + "");
+        lineCreateParams.put("duration", 10 + "");
         return lineCreateParams;
     }
 
@@ -144,6 +145,7 @@ class LineSectionAcceptanceTest extends AcceptanceTest {
         params.put("upStationId", upStationId + "");
         params.put("downStationId", downStationId + "");
         params.put("distance", 6 + "");
+        params.put("duration", 6 + "");
         return params;
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
@@ -3,15 +3,18 @@ package nextstep.subway.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.domain.SearchType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
+import org.springframework.test.context.ActiveProfiles;
 
 import java.util.HashMap;
 import java.util.Map;
 
 import static nextstep.subway.acceptance.LineSteps.지하철_노선에_지하철_구간_생성_요청;
+import static nextstep.subway.acceptance.PathSteps.경로_조회_요청;
 import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -41,32 +44,43 @@ class PathAcceptanceTest extends AcceptanceTest {
         양재역 = 지하철역_생성_요청("양재역").jsonPath().getLong("id");
         남부터미널역 = 지하철역_생성_요청("남부터미널역").jsonPath().getLong("id");
 
-        이호선 = 지하철_노선_생성_요청("2호선", "green", 교대역, 강남역, 10);
-        신분당선 = 지하철_노선_생성_요청("신분당선", "red", 강남역, 양재역, 10);
-        삼호선 = 지하철_노선_생성_요청("3호선", "orange", 교대역, 남부터미널역, 2);
+        이호선 = 지하철_노선_생성_요청("2호선", "green", 교대역, 강남역, 10, 10);
+        신분당선 = 지하철_노선_생성_요청("신분당선", "red", 강남역, 양재역, 10, 10);
+        삼호선 = 지하철_노선_생성_요청("3호선", "orange", 교대역, 남부터미널역, 2, 2);
 
-        지하철_노선에_지하철_구간_생성_요청(삼호선, createSectionCreateParams(남부터미널역, 양재역, 3));
+        지하철_노선에_지하철_구간_생성_요청(삼호선, createSectionCreateParams(남부터미널역, 양재역, 3, 3));
     }
 
     @DisplayName("두 역의 최단 거리 경로를 조회한다.")
     @Test
     void findPathByDistance() {
         // when
-        ExtractableResponse<Response> response = 두_역의_최단_거리_경로_조회를_요청(교대역, 양재역);
+        ExtractableResponse<Response> response = 경로_조회_요청(교대역, 양재역, SearchType.DISTANCE.name());
 
         // then
         assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(교대역, 남부터미널역, 양재역);
     }
 
-    private ExtractableResponse<Response> 두_역의_최단_거리_경로_조회를_요청(Long source, Long target) {
-        return RestAssured
-                .given().log().all()
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/paths?source={sourceId}&target={targetId}", source, target)
-                .then().log().all().extract();
+    /**
+     * Feature: 지하철 경로 검색
+     *
+     *   Scenario: 두 역의 최소 시간 경로를 조회
+     *     Given 지하철역이 등록되어있음
+     *     And 지하철 노선이 등록되어있음
+     *     And 지하철 노선에 지하철역이 등록되어있음
+     *     When 출발역에서 도착역까지의 최소 시간 기준으로 경로 조회를 요청
+     *     Then 최소 시간 기준 경로를 응답
+     *     And 총 거리와 소요 시간을 함께 응답함
+     */
+    @DisplayName("두 역의 최소 시간 경로를 조회한다.")
+    @Test
+    void findPathByDuration() {
+        ExtractableResponse<Response> response = 경로_조회_요청(교대역, 양재역, SearchType.DURATION.name());
+
+        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(교대역, 남부터미널역, 양재역);
     }
 
-    private Long 지하철_노선_생성_요청(String name, String color, Long upStation, Long downStation, int distance) {
+    private Long 지하철_노선_생성_요청(String name, String color, Long upStation, Long downStation, int distance, int duration) {
         Map<String, String> lineCreateParams;
         lineCreateParams = new HashMap<>();
         lineCreateParams.put("name", name);
@@ -74,15 +88,17 @@ class PathAcceptanceTest extends AcceptanceTest {
         lineCreateParams.put("upStationId", upStation + "");
         lineCreateParams.put("downStationId", downStation + "");
         lineCreateParams.put("distance", distance + "");
+        lineCreateParams.put("duration", duration + "");
 
         return LineSteps.지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
     }
 
-    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId, int distance) {
+    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId, int distance, int duration) {
         Map<String, String> params = new HashMap<>();
         params.put("upStationId", upStationId + "");
         params.put("downStationId", downStationId + "");
         params.put("distance", distance + "");
+        params.put("duration", duration + "");
         return params;
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
@@ -1,14 +1,11 @@
 package nextstep.subway.acceptance;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.domain.SearchType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.MediaType;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.HashMap;
 import java.util.Map;

--- a/src/test/java/nextstep/subway/acceptance/PathSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/PathSteps.java
@@ -9,23 +9,28 @@ import org.springframework.http.MediaType;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
-import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
-
 public class PathSteps {
 
-    public static ExtractableResponse<Response> 경로_조회_요청(RequestSpecification spec, Long source, Long target) {
+    public static ExtractableResponse<Response> 경로_조회_요청(Long source, Long target) {
         Map<String, Long> params = new HashMap<>();
         params.put("source", source);
         params.put("target", target);
 
         return RestAssured
-                .given(spec).log().all()
-                .filter(document("path",
-                        preprocessRequest(prettyPrint()),
-                        preprocessResponse(prettyPrint())))
+                .given().log().all()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .params(params)
+                .when().get("/paths")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 경로_조회_요청(Long source, Long target, RequestSpecification requestSpecification) {
+        Map<String, Long> params = new HashMap<>();
+        params.put("source", source);
+        params.put("target", target);
+
+        return requestSpecification
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .params(params)
                 .when().get("/paths")

--- a/src/test/java/nextstep/subway/acceptance/PathSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/PathSteps.java
@@ -6,33 +6,26 @@ import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
 import org.springframework.http.MediaType;
 
-import java.util.HashMap;
-import java.util.Map;
-
 public class PathSteps {
 
-    public static ExtractableResponse<Response> 경로_조회_요청(Long source, Long target) {
-        Map<String, Long> params = new HashMap<>();
-        params.put("source", source);
-        params.put("target", target);
-
+    public static ExtractableResponse<Response> 경로_조회_요청(Long source, Long target, String type) {
         return RestAssured
                 .given().log().all()
                 .accept(MediaType.APPLICATION_JSON_VALUE)
-                .params(params)
+                .queryParam("source", source)
+                .queryParam("target", target)
+                .queryParam("type", type)
                 .when().get("/paths")
                 .then().log().all()
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 경로_조회_요청(Long source, Long target, RequestSpecification requestSpecification) {
-        Map<String, Long> params = new HashMap<>();
-        params.put("source", source);
-        params.put("target", target);
-
+    public static ExtractableResponse<Response> 경로_조회_요청(Long source, Long target, String type, RequestSpecification requestSpecification) {
         return requestSpecification
                 .accept(MediaType.APPLICATION_JSON_VALUE)
-                .params(params)
+                .queryParam("source", source)
+                .queryParam("target", target)
+                .queryParam("type", type)
                 .when().get("/paths")
                 .then().log().all()
                 .extract();

--- a/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/SectionAcceptanceTest.java
@@ -84,6 +84,7 @@ class SectionAcceptanceTest extends AcceptanceTest {
         lineCreateParams.put("upStationId", upStationId + "");
         lineCreateParams.put("downStationId", downStationId + "");
         lineCreateParams.put("distance", 10 + "");
+        lineCreateParams.put("duration", 10 + "");
         return lineCreateParams;
     }
 
@@ -92,6 +93,7 @@ class SectionAcceptanceTest extends AcceptanceTest {
         params.put("upStationId", upStationId + "");
         params.put("downStationId", downStationId + "");
         params.put("distance", 6 + "");
+        params.put("duration", 6 + "");
         return params;
     }
 }

--- a/src/test/java/nextstep/subway/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/documentation/PathDocumentation.java
@@ -9,7 +9,6 @@ import nextstep.subway.applicaion.dto.PathResponse;
 import nextstep.subway.applicaion.dto.StationResponse;
 import nextstep.subway.domain.SearchType;
 import org.assertj.core.util.Lists;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
@@ -58,13 +57,15 @@ public class PathDocumentation extends Documentation {
                 .filter(document(documentIdentifier, preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint()),
                         requestParameters(
                                 parameterWithName("source").description("출발역 id"),
-                                parameterWithName("target").description("도착역 id")
+                                parameterWithName("target").description("도착역 id"),
+                                parameterWithName("type").description("경로 조회 조건")
                         ),
                         responseFields(
                                 fieldWithPath("stations").type(JsonFieldType.ARRAY).description("경로의 지하철 역 목록"),
                                 fieldWithPath("stations[].id").type(JsonFieldType.NUMBER).description("지하철 역 id"),
                                 fieldWithPath("stations[].name").type(JsonFieldType.STRING).description("지하철 역 이름"),
-                                fieldWithPath("distance").type(JsonFieldType.NUMBER).description("경로의 이동거리")
+                                fieldWithPath("distance").type(JsonFieldType.NUMBER).description("경로의 이동거리"),
+                                fieldWithPath("duration").type(JsonFieldType.NUMBER).description("경로의 이동시간")
                         )
                 ));
     }

--- a/src/test/java/nextstep/subway/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/documentation/PathDocumentation.java
@@ -16,6 +16,7 @@ import org.springframework.restdocs.payload.JsonFieldType;
 
 import static nextstep.subway.acceptance.PathSteps.경로_조회_요청;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
@@ -42,7 +43,7 @@ public class PathDocumentation extends Documentation {
                         new StationResponse(TARGET_ID, "역삼역")
                 ), 10
         );
-        when(pathService.findPath(anyLong(), anyLong())).thenReturn(pathResponse);
+        when(pathService.findPath(anyLong(), anyLong(), any(SearchType.class))).thenReturn(pathResponse);
 
         // When
         ExtractableResponse<Response> response = 경로_조회_요청(SOURCE_ID, TARGET_ID, SearchType.DURATION.name(), documentConfig("path"));

--- a/src/test/java/nextstep/subway/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/documentation/PathDocumentation.java
@@ -41,8 +41,7 @@ public class PathDocumentation extends Documentation {
                 Lists.newArrayList(
                         new StationResponse(SOURCE_ID, "강남역"),
                         new StationResponse(TARGET_ID, "역삼역")
-                ), 10
-        );
+                ), 10, 10);
         when(pathService.findPath(anyLong(), anyLong(), any(SearchType.class))).thenReturn(pathResponse);
 
         // When

--- a/src/test/java/nextstep/subway/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/documentation/PathDocumentation.java
@@ -7,7 +7,9 @@ import io.restassured.specification.RequestSpecification;
 import nextstep.subway.applicaion.PathService;
 import nextstep.subway.applicaion.dto.PathResponse;
 import nextstep.subway.applicaion.dto.StationResponse;
+import nextstep.subway.domain.SearchType;
 import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
@@ -44,7 +46,7 @@ public class PathDocumentation extends Documentation {
         when(pathService.findPath(anyLong(), anyLong())).thenReturn(pathResponse);
 
         // When
-        ExtractableResponse<Response> response = 경로_조회_요청(SOURCE_ID, TARGET_ID, documentConfig("path"));
+        ExtractableResponse<Response> response = 경로_조회_요청(SOURCE_ID, TARGET_ID, SearchType.DURATION.name(), documentConfig("path"));
 
         // Then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -44,7 +44,7 @@ class LineServiceMockTest {
         삼성역 = new Station("삼성역");
         ReflectionTestUtils.setField(삼성역, "id", 3L);
         이호선 = new Line("2호선", "green");
-        이호선.addSection(강남역, 역삼역, 10);
+        이호선.addSection(강남역, 역삼역, 10, 10);
         ReflectionTestUtils.setField(이호선, "id", 1L);
     }
 
@@ -54,7 +54,7 @@ class LineServiceMockTest {
         when(stationService.findById(역삼역.getId())).thenReturn(역삼역);
         when(stationService.findById(삼성역.getId())).thenReturn(삼성역);
 
-        lineService.addSection(이호선.getId(), new SectionRequest(역삼역.getId(), 삼성역.getId(), 10));
+        lineService.addSection(이호선.getId(), new SectionRequest(역삼역.getId(), 삼성역.getId(), 10, 10));
 
         Line line = lineService.findById(1L);
 

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -9,10 +9,12 @@ import nextstep.subway.domain.StationRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@ActiveProfiles("test")
 @SpringBootTest
 @Transactional
 class LineServiceTest {

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -33,7 +33,7 @@ class LineServiceTest {
         Station 삼성역 = stationRepository.save(new Station("삼성역"));
         Line 이호선 = lineRepository.save(createLine(강남역, 역삼역));
 
-        lineService.addSection(이호선.getId(), new SectionRequest(역삼역.getId(), 삼성역.getId(), 10));
+        lineService.addSection(이호선.getId(), new SectionRequest(역삼역.getId(), 삼성역.getId(), 10, 10));
 
         Line line = lineService.findById(이호선.getId());
 
@@ -42,7 +42,7 @@ class LineServiceTest {
 
     private Line createLine(Station 강남역, Station 역삼역) {
         Line line = new Line("2호선", "green");
-        line.addSection(강남역, 역삼역, 10);
+        line.addSection(강남역, 역삼역, 10, 10);
         return line;
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -19,8 +19,8 @@ class LineTest {
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
 
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(역삼역, 삼성역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(역삼역, 삼성역, 5, 5);
 
         assertThat(line.getStations()).containsExactly(강남역, 역삼역, 삼성역);
     }
@@ -33,8 +33,8 @@ class LineTest {
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
 
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(강남역, 삼성역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(강남역, 삼성역, 5, 5);
 
         assertThat(line.getSections().size()).isEqualTo(2);
         Section section = line.getSections().stream()
@@ -52,8 +52,8 @@ class LineTest {
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
 
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(삼성역, 역삼역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(삼성역, 역삼역, 5, 5);
 
         assertThat(line.getSections().size()).isEqualTo(2);
         Section section = line.getSections().stream()
@@ -71,8 +71,8 @@ class LineTest {
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
 
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(삼성역, 강남역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(삼성역, 강남역, 5, 5);
 
         assertThat(line.getSections().size()).isEqualTo(2);
         Section section = line.getSections().stream()
@@ -90,8 +90,8 @@ class LineTest {
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
 
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(역삼역, 삼성역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(역삼역, 삼성역, 5, 5);
 
         assertThat(line.getSections().size()).isEqualTo(2);
         Section section = line.getSections().stream()
@@ -107,8 +107,8 @@ class LineTest {
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(강남역, 삼성역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(강남역, 삼성역, 5, 5);
 
         List<Station> result = line.getStations();
 
@@ -121,9 +121,9 @@ class LineTest {
         Station 강남역 = new Station("강남역");
         Station 역삼역 = new Station("역삼역");
         Line line = new Line("2호선", "green");
-        line.addSection(강남역, 역삼역, 10);
+        line.addSection(강남역, 역삼역, 10, 10);
 
-        assertThatThrownBy(() -> line.addSection(강남역, 역삼역, 5))
+        assertThatThrownBy(() -> line.addSection(강남역, 역삼역, 5, 5))
                 .isInstanceOf(IllegalArgumentException.class);
     }
 
@@ -133,8 +133,8 @@ class LineTest {
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(역삼역, 삼성역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(역삼역, 삼성역, 5, 5);
 
         line.deleteSection(삼성역);
 
@@ -147,8 +147,8 @@ class LineTest {
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(역삼역, 삼성역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(역삼역, 삼성역, 5, 5);
 
         line.deleteSection(강남역);
 
@@ -161,8 +161,8 @@ class LineTest {
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
         Line line = new Line("2호선", "green");
-        line.addSection(강남역, 역삼역, 10);
-        line.addSection(역삼역, 삼성역, 5);
+        line.addSection(강남역, 역삼역, 10, 10);
+        line.addSection(역삼역, 삼성역, 5, 5);
 
         line.deleteSection(역삼역);
 
@@ -175,7 +175,7 @@ class LineTest {
         Station 강남역 = new Station("강남역");
         Station 역삼역 = new Station("역삼역");
         Line line = new Line("2호선", "green");
-        line.addSection(강남역, 역삼역, 10);
+        line.addSection(강남역, 역삼역, 10, 10);
 
         assertThatThrownBy(() -> line.deleteSection(역삼역))
                 .isInstanceOf(IllegalArgumentException.class);

--- a/src/test/java/nextstep/subway/unit/SectionsTest.java
+++ b/src/test/java/nextstep/subway/unit/SectionsTest.java
@@ -4,32 +4,40 @@ import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Section;
 import nextstep.subway.domain.Sections;
 import nextstep.subway.domain.Station;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 public class SectionsTest {
 
-    @DisplayName("상행 기준으로 목록 중간에 추가할 경우")
-    @Test
-    void addSectionInMiddle() {
+    private Station 강남역;
+    private Station 역삼역;
+    private Line 이호선;
+    private Sections sections;
+
+    @BeforeEach
+    void setUp() {
         // Given
-        Station 강남역 = new Station("강남역");
-        Station 역삼역 = new Station("역삼역");
-        Station 삼성역 = new Station("삼성역");
-        Line 이호선 = new Line("2호선", "green");
+        강남역 = new Station("강남역");
+        역삼역 = new Station("역삼역");
+        이호선 = new Line("2호선", "green");
 
         ArrayList<Section> initialSection = new ArrayList<>();
         initialSection.add(new Section(이호선, 강남역, 역삼역, 10, 10));
 
-        Sections sections = new Sections(initialSection);
+        sections = new Sections(initialSection);
+    }
+
+    @DisplayName("상행 기준으로 목록 중간에 추가할 경우")
+    @Test
+    void addSectionInMiddle() {
+        // Given
+        Station 삼성역 = new Station("삼성역");
 
         // When
         sections.add(new Section(이호선, 강남역, 삼성역, 5, 5));
@@ -51,15 +59,7 @@ public class SectionsTest {
     @Test
     void addSectionInMiddle2() {
         // Given
-        Station 강남역 = new Station("강남역");
-        Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
-        Line 이호선 = new Line("2호선", "green");
-
-        ArrayList<Section> initialSection = new ArrayList<>();
-        initialSection.add(new Section(이호선, 강남역, 역삼역, 10, 10));
-
-        Sections sections = new Sections(initialSection);
 
         // When
         sections.add(new Section(이호선, 삼성역, 역삼역, 5, 5));
@@ -75,5 +75,49 @@ public class SectionsTest {
                 () -> assertThat(section.getDistance()).isEqualTo(5),
                 () -> assertThat(section.getDuration()).isEqualTo(5)
         );
+    }
+
+    /**
+     * (이동거리)
+     *
+     * 강남역 <-5-> 삼성역 <-5-> 역삼역 <-3-> 잠실역
+     */
+    @DisplayName("구간의 이동거리")
+    @Test
+    void totalDistance() {
+        // Given
+        Station 삼성역 = new Station("삼성역");
+        sections.add(new Section(이호선, 강남역, 삼성역, 5, 5));
+
+        Station 잠실역 = new Station("잠실역");
+        sections.add(new Section(이호선, 역삼역, 잠실역, 3, 3));
+
+        // When
+        int totalDistance = sections.totalDistance();
+
+        // Then
+        assertThat(totalDistance).isEqualTo(13);
+    }
+
+    /**
+     * (이동시간)
+     *
+     * 강남역 <-5-> 삼성역 <-5-> 역삼역 <-3-> 잠실역
+     */
+    @DisplayName("구간의 이동시간")
+    @Test
+    void totalDuration() {
+        // Given
+        Station 삼성역 = new Station("삼성역");
+        sections.add(new Section(이호선, 강남역, 삼성역, 5, 5));
+
+        Station 잠실역 = new Station("잠실역");
+        sections.add(new Section(이호선, 역삼역, 잠실역, 3, 3));
+
+        // When
+        int totalDuration = sections.totalDuration();
+
+        // Then
+        assertThat(totalDuration).isEqualTo(13);
     }
 }

--- a/src/test/java/nextstep/subway/unit/SectionsTest.java
+++ b/src/test/java/nextstep/subway/unit/SectionsTest.java
@@ -1,0 +1,79 @@
+package nextstep.subway.unit;
+
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.Sections;
+import nextstep.subway.domain.Station;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+public class SectionsTest {
+
+    @DisplayName("상행 기준으로 목록 중간에 추가할 경우")
+    @Test
+    void addSectionInMiddle() {
+        // Given
+        Station 강남역 = new Station("강남역");
+        Station 역삼역 = new Station("역삼역");
+        Station 삼성역 = new Station("삼성역");
+        Line 이호선 = new Line("2호선", "green");
+
+        ArrayList<Section> initialSection = new ArrayList<>();
+        initialSection.add(new Section(이호선, 강남역, 역삼역, 10, 10));
+
+        Sections sections = new Sections(initialSection);
+
+        // When
+        sections.add(new Section(이호선, 강남역, 삼성역, 5, 5));
+
+        // Then
+        Section section = sections.getSections().stream()
+                .filter(it -> it.getUpStation() == 강남역)
+                .findFirst()
+                .orElseThrow(RuntimeException::new);
+
+        assertAll(
+                () -> assertThat(section.getDownStation()).isEqualTo(삼성역),
+                () -> assertThat(section.getDistance()).isEqualTo(5),
+                () -> assertThat(section.getDuration()).isEqualTo(5)
+        );
+    }
+
+    @DisplayName("하행 기준으로 목록 중간에 추가할 경우")
+    @Test
+    void addSectionInMiddle2() {
+        // Given
+        Station 강남역 = new Station("강남역");
+        Station 역삼역 = new Station("역삼역");
+        Station 삼성역 = new Station("삼성역");
+        Line 이호선 = new Line("2호선", "green");
+
+        ArrayList<Section> initialSection = new ArrayList<>();
+        initialSection.add(new Section(이호선, 강남역, 역삼역, 10, 10));
+
+        Sections sections = new Sections(initialSection);
+
+        // When
+        sections.add(new Section(이호선, 삼성역, 역삼역, 5, 5));
+
+        Section section = sections.getSections().stream()
+                .filter(it -> it.getUpStation() == 강남역)
+                .findFirst()
+                .orElseThrow(RuntimeException::new);
+
+        // Then
+        assertAll(
+                () -> assertThat(section.getDownStation()).isEqualTo(삼성역),
+                () -> assertThat(section.getDistance()).isEqualTo(5),
+                () -> assertThat(section.getDuration()).isEqualTo(5)
+        );
+    }
+}

--- a/src/test/java/nextstep/subway/unit/SubwayMapTest.java
+++ b/src/test/java/nextstep/subway/unit/SubwayMapTest.java
@@ -7,7 +7,6 @@ import nextstep.subway.domain.Station;
 import nextstep.subway.domain.SubwayMap;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 

--- a/src/test/java/nextstep/subway/unit/SubwayMapTest.java
+++ b/src/test/java/nextstep/subway/unit/SubwayMapTest.java
@@ -2,10 +2,12 @@ package nextstep.subway.unit;
 
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Path;
+import nextstep.subway.domain.SearchType;
 import nextstep.subway.domain.Station;
 import nextstep.subway.domain.SubwayMap;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
@@ -22,6 +24,8 @@ public class SubwayMapTest {
     private Line 신분당선;
     private Line 이호선;
     private Line 삼호선;
+    private SubwayMap subwayMapWeightOnDistance;
+    private SubwayMap subwayMapWeightOnDuration;
 
     @BeforeEach
     void setUp() {
@@ -38,29 +42,43 @@ public class SubwayMapTest {
         이호선.addSection(교대역, 강남역, 3, 3);
         삼호선.addSection(교대역, 남부터미널역, 5, 5);
         삼호선.addSection(남부터미널역, 양재역, 5, 5);
+
+        List<Line> lines = Lists.newArrayList(신분당선, 이호선, 삼호선);
+        subwayMapWeightOnDistance = new SubwayMap(lines, SearchType.DISTANCE);
+        subwayMapWeightOnDuration = new SubwayMap(lines, SearchType.DURATION);
     }
 
     @Test
-    void findPath() {
-        // given
-        List<Line> lines = Lists.newArrayList(신분당선, 이호선, 삼호선);
-        SubwayMap subwayMap = new SubwayMap(lines);
-
+    void findPathOnDistance() {
         // when
-        Path path = subwayMap.findPath(교대역, 양재역);
+        Path path = subwayMapWeightOnDistance.findPath(교대역, 양재역);
 
         // then
         assertThat(path.getStations()).containsExactlyElementsOf(Lists.newArrayList(교대역, 강남역, 양재역));
     }
 
     @Test
-    void findPathOppositely() {
-        // given
-        List<Line> lines = Lists.newArrayList(신분당선, 이호선, 삼호선);
-        SubwayMap subwayMap = new SubwayMap(lines);
-
+    void findPathOnDuration() {
         // when
-        Path path = subwayMap.findPath(양재역, 교대역);
+        Path path = subwayMapWeightOnDuration.findPath(교대역, 양재역);
+
+        // then
+        assertThat(path.getStations()).containsExactlyElementsOf(Lists.newArrayList(교대역, 강남역, 양재역));
+    }
+
+    @Test
+    void findPathOppositelyOnDistance() {
+        // when
+        Path path = subwayMapWeightOnDistance.findPath(양재역, 교대역);
+
+        // then
+        assertThat(path.getStations()).containsExactlyElementsOf(Lists.newArrayList(양재역, 강남역, 교대역));
+    }
+
+    @Test
+    void findPathOppositelyOnDuration() {
+        // when
+        Path path = subwayMapWeightOnDuration.findPath(양재역, 교대역);
 
         // then
         assertThat(path.getStations()).containsExactlyElementsOf(Lists.newArrayList(양재역, 강남역, 교대역));

--- a/src/test/java/nextstep/subway/unit/SubwayMapTest.java
+++ b/src/test/java/nextstep/subway/unit/SubwayMapTest.java
@@ -34,10 +34,10 @@ public class SubwayMapTest {
         이호선 = new Line("2호선", "red");
         삼호선 = new Line("3호선", "red");
 
-        신분당선.addSection(강남역, 양재역, 3);
-        이호선.addSection(교대역, 강남역, 3);
-        삼호선.addSection(교대역, 남부터미널역, 5);
-        삼호선.addSection(남부터미널역, 양재역, 5);
+        신분당선.addSection(강남역, 양재역, 3, 3);
+        이호선.addSection(교대역, 강남역, 3, 3);
+        삼호선.addSection(교대역, 남부터미널역, 5, 5);
+        삼호선.addSection(남부터미널역, 양재역, 5, 5);
     }
 
     @Test

--- a/src/test/java/nextstep/subway/utils/DataLoader.java
+++ b/src/test/java/nextstep/subway/utils/DataLoader.java
@@ -3,12 +3,12 @@ package nextstep.subway.utils;
 import nextstep.member.domain.Member;
 import nextstep.member.domain.MemberRepository;
 import nextstep.member.domain.RoleType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
-import org.springframework.test.context.ActiveProfiles;
 
 import java.util.Arrays;
 
-@ActiveProfiles("test")
+@Profile("test")
 @Component
 public class DataLoader {
     private MemberRepository memberRepository;


### PR DESCRIPTION
안녕하세요 성현님! 경로 조회 타입 추가 미션 진행했습니다!
지난 미션에서 코멘트 남겨주셨던 부분 https://github.com/next-step/atdd-subway-fare/pull/247#discussion_r1118020839 
`중복 제거: 
spec을 설정하는 부분과 filter 설정하는 부분을 RequestSpecification 객체로 주입 받을 경우 나머지 RestAssured 부분은 인수 테스트의 Step과 함께 사용할 수 있음` 을 참고하여 리팩토링했습니다 6ec99013341c6a4b46099340867d07d08cbad749

이번 미션에서, `개발 흐름을 파악할 수 있도록 커밋을 작은 단위로 나누어 구현해보세요.` 이라는 요구사항이 있었는데요. 작성 하고보니 커밋만 보고서 개발흐름이 읽히진 않는 것 같습니다 😭