### PR TITLE
🚀 실습 - 문서화

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # 지하철 노선도 미션
 [ATDD 강의](https://edu.nextstep.camp/c/R89PYi5H) 실습을 위한 지하철 노선도 애플리케이션
+## 🚀 실습 - 문서화
+### 요구사항
+- [ ] 경로 찾기 기능을 문서화하기 위한 테스트를 작성하세요. 
+  1. PathDocumentation의 path 메서드를 완성시키세요.
+  2. PathDocumentation의 테스트를 수행시켜 snippet을 생성하세요. 
+  3. gradle로 asciidoctor task를 수행시켜 문서 파일을 생성하세요.
+  4. build > asciidoc > html5 > index.html을 브라우저로 열고 캡쳐한 이미지를 PR에 포함시켜 주세요. 
+  5. PathSteps 클래스를 활용하여 PathDocumentation 내 코드 중복을 제거해주세요.
+- [ ] 테스트 작성 후 Spring Rest Docs 적용을 통해 문서에 기재할 정보를 설정하세요.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,10 @@
 [ATDD 강의](https://edu.nextstep.camp/c/R89PYi5H) 실습을 위한 지하철 노선도 애플리케이션
 ## 🚀 실습 - 문서화
 ### 요구사항
-- [ ] 경로 찾기 기능을 문서화하기 위한 테스트를 작성하세요. 
+- [x] 경로 찾기 기능을 문서화하기 위한 테스트를 작성하세요. 
   1. PathDocumentation의 path 메서드를 완성시키세요.
   2. PathDocumentation의 테스트를 수행시켜 snippet을 생성하세요. 
   3. gradle로 asciidoctor task를 수행시켜 문서 파일을 생성하세요.
   4. build > asciidoc > html5 > index.html을 브라우저로 열고 캡쳐한 이미지를 PR에 포함시켜 주세요. 
   5. PathSteps 클래스를 활용하여 PathDocumentation 내 코드 중복을 제거해주세요.
-- [ ] 테스트 작성 후 Spring Rest Docs 적용을 통해 문서에 기재할 정보를 설정하세요.
+- [x] 테스트 작성 후 Spring Rest Docs 적용을 통해 문서에 기재할 정보를 설정하세요.

--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -11,4 +11,4 @@
 
 === 경로 조회
 
-operation::path[snippets='http-request,http-response']
+operation::path[snippets='http-request,request-parameters,http-response']

--- a/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
@@ -3,6 +3,7 @@ package nextstep.subway.acceptance;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,7 +13,9 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static nextstep.subway.acceptance.LineSteps.지하철_노선에_지하철_구간_생성_요청;
+import static nextstep.subway.acceptance.PathSteps.두_역의_최단_거리_경로_조회를_요청;
 import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
+import static nextstep.subway.acceptance.Steps.defaultRequestSpecification;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @DisplayName("지하철 경로 검색")
@@ -52,18 +55,10 @@ class PathAcceptanceTest extends AcceptanceTest {
     @Test
     void findPathByDistance() {
         // when
-        ExtractableResponse<Response> response = 두_역의_최단_거리_경로_조회를_요청(교대역, 양재역);
+        ExtractableResponse<Response> response = 두_역의_최단_거리_경로_조회를_요청(defaultRequestSpecification(), 교대역, 양재역);
 
         // then
         assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(교대역, 남부터미널역, 양재역);
-    }
-
-    private ExtractableResponse<Response> 두_역의_최단_거리_경로_조회를_요청(Long source, Long target) {
-        return RestAssured
-                .given().log().all()
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .when().get("/paths?source={sourceId}&target={targetId}", source, target)
-                .then().log().all().extract();
     }
 
     private Long 지하철_노선_생성_요청(String name, String color, Long upStation, Long downStation, int distance) {

--- a/src/test/java/nextstep/subway/acceptance/PathSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/PathSteps.java
@@ -1,0 +1,19 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import io.restassured.specification.RequestSpecification;
+import org.springframework.http.MediaType;
+
+public class PathSteps {
+
+    public static ExtractableResponse<Response> 두_역의_최단_거리_경로_조회를_요청(final RequestSpecification requestSpecification, final long source, final long target) {
+        return requestSpecification
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("source", source)
+                .queryParam("target", target)
+                .when().get("/paths")
+                .then().log().all()
+                .extract();
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/Steps.java
+++ b/src/test/java/nextstep/subway/acceptance/Steps.java
@@ -1,0 +1,12 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.specification.RequestSpecification;
+
+public class Steps {
+
+    public static RequestSpecification defaultRequestSpecification() {
+        return RestAssured
+                .given().log().all();
+    }
+}

--- a/src/test/java/nextstep/subway/documentation/Documentation.java
+++ b/src/test/java/nextstep/subway/documentation/Documentation.java
@@ -12,7 +12,7 @@ import org.springframework.test.context.ActiveProfiles;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
 
 @ActiveProfiles("test")
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ExtendWith(RestDocumentationExtension.class)
 public class Documentation {
     protected RequestSpecification spec;

--- a/src/test/java/nextstep/subway/documentation/Documentation.java
+++ b/src/test/java/nextstep/subway/documentation/Documentation.java
@@ -1,10 +1,12 @@
 package nextstep.subway.documentation;
 
+import io.restassured.RestAssured;
 import io.restassured.builder.RequestSpecBuilder;
 import io.restassured.specification.RequestSpecification;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.test.context.ActiveProfiles;
@@ -15,10 +17,14 @@ import static org.springframework.restdocs.restassured3.RestAssuredRestDocumenta
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @ExtendWith(RestDocumentationExtension.class)
 public class Documentation {
+
+    @LocalServerPort
+    private int port;
     protected RequestSpecification spec;
 
     @BeforeEach
     public void setUp(RestDocumentationContextProvider restDocumentation) {
+        RestAssured.port = port;
         this.spec = new RequestSpecBuilder()
                 .addFilter(documentationConfiguration(restDocumentation))
                 .build();

--- a/src/test/java/nextstep/subway/documentation/Documentation.java
+++ b/src/test/java/nextstep/subway/documentation/Documentation.java
@@ -29,4 +29,9 @@ public class Documentation {
                 .addFilter(documentationConfiguration(restDocumentation))
                 .build();
     }
+
+    protected RequestSpecification documentRequestSpecification() {
+        return RestAssured
+                .given(spec).log().all();
+    }
 }

--- a/src/test/java/nextstep/subway/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/documentation/PathDocumentation.java
@@ -1,6 +1,5 @@
 package nextstep.subway.documentation;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
@@ -23,6 +22,7 @@ import static org.springframework.restdocs.restassured3.RestAssuredRestDocumenta
 
 public class PathDocumentation extends Documentation {
 
+    private static final String FIND_PATH = "path";
     @MockBean
     private PathService pathService;
 
@@ -35,9 +35,8 @@ public class PathDocumentation extends Documentation {
                 ), 10);
         when(pathService.findPath(anyLong(), anyLong())).thenReturn(pathResponse);
 
-        final RequestSpecification requestSpec = RestAssured
-                .given(spec).log().all()
-                .filter(document("path",
+        final RequestSpecification requestSpec = documentRequestSpecification()
+                .filter(document(FIND_PATH,
                         preprocessRequest(prettyPrint()),
                         preprocessResponse(prettyPrint()),
                         requestParameters(

--- a/src/test/java/nextstep/subway/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/documentation/PathDocumentation.java
@@ -1,15 +1,46 @@
 package nextstep.subway.documentation;
 
 import io.restassured.RestAssured;
+import nextstep.subway.applicaion.PathService;
+import nextstep.subway.applicaion.dto.PathResponse;
+import nextstep.subway.applicaion.dto.StationResponse;
+import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 public class PathDocumentation extends Documentation {
 
+    @MockBean
+    private PathService pathService;
+
     @Test
     void path() {
+        final PathResponse pathResponse = new PathResponse(
+                Lists.newArrayList(
+                        new StationResponse(1L, "강남역"),
+                        new StationResponse(2L, "역삼역")
+                ), 10
+        );
+
+        when(pathService.findPath(anyLong(), anyLong())).thenReturn(pathResponse);
+
         RestAssured
-                .given().log().all()
+                .given(spec).log().all()
+                .filter(document("path",
+                        preprocessRequest(prettyPrint()),
+                        preprocessResponse(prettyPrint()),
+                        requestParameters(
+                                parameterWithName("source").description("출발역"),
+                                parameterWithName("target").description("도착역")
+                        )))
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .queryParam("source", 1L)
                 .queryParam("target", 2L)

--- a/src/test/java/nextstep/subway/utils/DataLoaderBootstrap.java
+++ b/src/test/java/nextstep/subway/utils/DataLoaderBootstrap.java
@@ -1,9 +1,11 @@
 package nextstep.subway.utils;
 
 import org.springframework.context.ApplicationListener;
+import org.springframework.context.annotation.Profile;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.stereotype.Component;
 
+@Profile("test")
 @Component
 public class DataLoaderBootstrap implements ApplicationListener<ContextRefreshedEvent> {
     private DataLoader dataLoader;


### PR DESCRIPTION
안녕하세요, 이슬님!
늦게 시작했지만 마지막 주차 미션동안 잘 부탁드립니다 🙇‍♂️

[개발 사항]
- 경로 조회에 대한 문서화 테스트 코드 작성
- Step 객체의 메서드를 이용하여 RestAssured 콜을 보내도록 개선

Step 객체의 메서드의 인자로 RequestSpecification 을 넘기면 Documentation 에서는 크게 불편한 점이 없는데, AcceptanceTest 코드 안에서는 같은 코드가 중복되어 작성될 것 같아 Step 이라는 BaseClass 안에 정적 메서드로 기본 RequestSpecification 을 생성할 수 있도록 하였습니다.
Step 이라는 BaseClass 에 아직은 공통 코드가 많지 않아 모든 Step 클래스들이 상속받도록 하지 않았는데 이후 미
션을 진행하며 상속받게 될 것 같아 이렇게 개발 진행했습니다!

<img width="1023" alt="Screen Shot 2023-03-04 at 2 10 46 AM" src="https://user-images.githubusercontent.com/31237832/222783917-0b8b0dd5-b397-448a-8111-5599583e824d.png">