### PR TITLE
요금 조회 미션

### DIFF
--- a/src/main/java/nextstep/subway/applicaion/dto/PathResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/PathResponse.java
@@ -9,11 +9,13 @@ public class PathResponse {
     private List<StationResponse> stations;
     private int distance;
     private int duration;
+    private int fare;
 
-    public PathResponse(List<StationResponse> stations, int distance, int duration) {
+    public PathResponse(List<StationResponse> stations, int distance, int duration, int fare) {
         this.stations = stations;
         this.distance = distance;
         this.duration = duration;
+        this.fare = fare;
     }
 
     public static PathResponse of(Path path) {
@@ -22,8 +24,9 @@ public class PathResponse {
                 .collect(Collectors.toList());
         int distance = path.extractDistance();
         int duration = path.extractDuration();
+        int fare = path.extractFare();
 
-        return new PathResponse(stations, distance, duration);
+        return new PathResponse(stations, distance, duration, fare);
     }
 
     public List<StationResponse> getStations() {
@@ -36,5 +39,9 @@ public class PathResponse {
 
     public int getDuration() {
         return duration;
+    }
+
+    public int getFare() {
+        return fare;
     }
 }

--- a/src/main/java/nextstep/subway/domain/FarePolicy.java
+++ b/src/main/java/nextstep/subway/domain/FarePolicy.java
@@ -1,0 +1,57 @@
+package nextstep.subway.domain;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
+
+public enum FarePolicy {
+    NOT_MORE_THAN_10KM (
+            distance -> distance <= Constants.TEN_KM,
+            distance -> 0
+    ),
+    MORE_THAN_10KM_AND_NOT_MORE_THAN_50KM(
+            distance -> Constants.TEN_KM < distance && distance <= Constants.FIFTY_KM,
+            distance -> calculateExtraFare(Constants.TEN_KM, distance, Constants.PER_FIVE_KM)
+    ),
+    MORE_THAN_50KM(
+            distance -> Constants.FIFTY_KM < distance,
+            distance -> calculateExtraFare(Constants.TEN_KM, Constants.FIFTY_KM, Constants.PER_FIVE_KM)
+                    + calculateExtraFare(Constants.FIFTY_KM, distance, Constants.PER_EIGHT_KM)
+    );
+
+    private final Predicate<Integer> predicate;
+    private final UnaryOperator<Integer> extraFareOperator;
+
+    FarePolicy(Predicate<Integer> predicate, UnaryOperator<Integer> extraFareOperator) {
+        this.predicate = predicate;
+        this.extraFareOperator = extraFareOperator;
+    }
+
+    public static int calculate(int distance) {
+        return Constants.DEFAULT_FARE + getExtraFare(distance);
+    }
+
+    private static Integer getExtraFare(int distance) {
+        Integer extraFare = Arrays.stream(values())
+                .filter(it -> it.predicate.test(distance))
+                .findFirst()
+                .orElse(NOT_MORE_THAN_10KM)
+                .extraFareOperator.apply(distance);
+        return extraFare;
+    }
+
+    private static int calculateExtraFare(int start, int end, int unit) {
+        return (int) ((Math.ceil((end - start - 1) / unit) + 1) * 100);
+    }
+
+    private static class Constants {
+
+        public static final int DEFAULT_FARE = 1250;
+
+        public static final int TEN_KM = 10;
+        public static final int FIFTY_KM = 50;
+
+        public static final int PER_FIVE_KM = 5;
+        public static final int PER_EIGHT_KM = 8;
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Path.java
+++ b/src/main/java/nextstep/subway/domain/Path.java
@@ -24,4 +24,8 @@ public class Path {
     public List<Station> getStations() {
         return sections.getStations();
     }
+
+    public int extractFare() {
+        return FarePolicy.calculate(extractDistance());
+    }
 }

--- a/src/test/java/nextstep/subway/acceptance/FareAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FareAcceptanceTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.util.HashMap;
 import java.util.Map;
 
+import static nextstep.subway.acceptance.LineSteps.지하철_노선에_지하철_구간_생성_요청;
 import static nextstep.subway.acceptance.PathSteps.경로_조회_요청;
 import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -41,11 +42,11 @@ public class FareAcceptanceTest extends AcceptanceTest {
 
     /**
      * <이동거리|이동시간>
-     * 교대역 --- <10|10> --- 강남역 --- <2|2> --- 역삼역 --- <3|3> --- 선릉역  --- <1|1> --- 왕십리역
+     * 교대역 --- <10|10> --- 강남역 --- <2|2> --- 역삼역 --- <3|3> --- 선릉역  --- <1|1> --- 왕십리역 *하행종착역*
      * |
      * <50|50>
      * |
-     * 신촌역 --- <8|8> --- 종합운동작역 --- <4|4> --- 건대입구역 --- <4|4> --- 사당역
+     * 신촌역 --- <8|8> --- 종합운동작역 --- <4|4> --- 건대입구역 --- <4|4> --- 사당역 *상행종착역*
      */
     @Override
     @BeforeEach
@@ -63,6 +64,14 @@ public class FareAcceptanceTest extends AcceptanceTest {
         사당역 = 지하철역_생성_요청("사당역").jsonPath().getLong("id");
 
         이호선 = 지하철_노선_생성_요청("2호선", "green", 교대역, 강남역, 10, 10);
+        지하철_노선에_지하철_구간_생성_요청(이호선, createSectionCreateParams(강남역, 역삼역, 2, 2));
+        지하철_노선에_지하철_구간_생성_요청(이호선, createSectionCreateParams(역삼역, 선릉역, 3, 3));
+        지하철_노선에_지하철_구간_생성_요청(이호선, createSectionCreateParams(선릉역, 왕십리역, 1, 1));
+
+        지하철_노선에_지하철_구간_생성_요청(이호선, createSectionCreateParams(신촌역, 교대역, 50, 50));
+        지하철_노선에_지하철_구간_생성_요청(이호선, createSectionCreateParams(종합운동장역, 신촌역, 8, 8));
+        지하철_노선에_지하철_구간_생성_요청(이호선, createSectionCreateParams(건대입구역, 종합운동장역, 4, 4));
+        지하철_노선에_지하철_구간_생성_요청(이호선, createSectionCreateParams(사당역, 건대입구역, 4, 4));
     }
 
     @Nested
@@ -154,7 +163,7 @@ public class FareAcceptanceTest extends AcceptanceTest {
 
             assertAll(
                     () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(62),
-                    () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(2_150)
+                    () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(2_250)
             );
         }
 
@@ -180,5 +189,14 @@ public class FareAcceptanceTest extends AcceptanceTest {
         lineCreateParams.put("duration", duration + "");
 
         return LineSteps.지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
+    }
+
+    private Map<String, String> createSectionCreateParams(Long upStationId, Long downStationId, int distance, int duration) {
+        Map<String, String> params = new HashMap<>();
+        params.put("upStationId", upStationId + "");
+        params.put("downStationId", downStationId + "");
+        params.put("distance", distance + "");
+        params.put("duration", duration + "");
+        return params;
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/FareAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/FareAcceptanceTest.java
@@ -1,0 +1,184 @@
+package nextstep.subway.acceptance;
+
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.domain.SearchType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static nextstep.subway.acceptance.PathSteps.경로_조회_요청;
+import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+/**
+ * 지하철 운임은 거리비례제로 책정됩니다. (실제 경로가 아닌 최단거리 기준)
+ * <p>
+ * 기본운임(10㎞ 이내) : 기본운임 1,250원
+ * 이용 거리초과 시 추가운임 부과
+ * 10km초과∼50km까지(5km마다 100원)
+ * 50km초과 시 (8km마다 100원)
+ */
+@DisplayName("요금 계산 인수 테스트")
+public class FareAcceptanceTest extends AcceptanceTest {
+
+    private Long 교대역;
+    private Long 강남역;
+    private Long 역삼역;
+    private Long 선릉역;
+    private Long 왕십리역;
+    private Long 신촌역;
+    private Long 종합운동장역;
+    private Long 건대입구역;
+    private Long 사당역;
+
+    private Long 이호선;
+
+    /**
+     * <이동거리|이동시간>
+     * 교대역 --- <10|10> --- 강남역 --- <2|2> --- 역삼역 --- <3|3> --- 선릉역  --- <1|1> --- 왕십리역
+     * |
+     * <50|50>
+     * |
+     * 신촌역 --- <8|8> --- 종합운동작역 --- <4|4> --- 건대입구역 --- <4|4> --- 사당역
+     */
+    @Override
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+
+        교대역 = 지하철역_생성_요청("교대역").jsonPath().getLong("id");
+        강남역 = 지하철역_생성_요청("강남역").jsonPath().getLong("id");
+        역삼역 = 지하철역_생성_요청("역삼역").jsonPath().getLong("id");
+        선릉역 = 지하철역_생성_요청("선릉역").jsonPath().getLong("id");
+        왕십리역 = 지하철역_생성_요청("왕십리역").jsonPath().getLong("id");
+        신촌역 = 지하철역_생성_요청("신촌역").jsonPath().getLong("id");
+        종합운동장역 = 지하철역_생성_요청("종합운동장역").jsonPath().getLong("id");
+        건대입구역 = 지하철역_생성_요청("건대입구역").jsonPath().getLong("id");
+        사당역 = 지하철역_생성_요청("사당역").jsonPath().getLong("id");
+
+        이호선 = 지하철_노선_생성_요청("2호선", "green", 교대역, 강남역, 10, 10);
+    }
+
+    @Nested
+    @DisplayName("10km 이하")
+    class NotMoreThan10 {
+        @Test
+        void distance2() {
+            ExtractableResponse<Response> response = 경로_조회_요청(강남역, 역삼역, SearchType.DURATION.name());
+
+            assertAll(
+                    () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(2),
+                    () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(1_250)
+            );
+        }
+
+        @Test
+        void distance10() {
+            ExtractableResponse<Response> response = 경로_조회_요청(교대역, 강남역, SearchType.DURATION.name());
+
+            assertAll(
+                    () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(10),
+                    () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(1_250)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("10km 초과, 50km 이하")
+    class MoreThan10NotMoreThan50 {
+
+        @Test
+        void distance12() {
+            ExtractableResponse<Response> response = 경로_조회_요청(교대역, 역삼역, SearchType.DURATION.name());
+
+            assertAll(
+                    () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(12),
+                    () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(1_350)
+            );
+        }
+
+        @Test
+        void distance15() {
+            ExtractableResponse<Response> response = 경로_조회_요청(교대역, 선릉역, SearchType.DURATION.name());
+
+            assertAll(
+                    () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(15),
+                    () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(1_350)
+            );
+        }
+
+        @Test
+        void distance16() {
+            ExtractableResponse<Response> response = 경로_조회_요청(교대역, 왕십리역, SearchType.DURATION.name());
+
+            assertAll(
+                    () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(16),
+                    () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(1_450)
+            );
+        }
+    }
+
+    @Nested
+    @DisplayName("50km 초과")
+    class MoreThan50 {
+
+        @Test
+        void distance50() {
+            ExtractableResponse<Response> response = 경로_조회_요청(교대역, 신촌역, SearchType.DURATION.name());
+
+            assertAll(
+                    () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(50),
+                    () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(2_050)
+            );
+        }
+
+        @Test
+        void distance58() {
+            ExtractableResponse<Response> response = 경로_조회_요청(교대역, 종합운동장역, SearchType.DURATION.name());
+
+            assertAll(
+                    () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(58),
+                    () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(2_150)
+            );
+        }
+
+        @Test
+        void distance62() {
+            ExtractableResponse<Response> response = 경로_조회_요청(교대역, 건대입구역, SearchType.DURATION.name());
+
+            assertAll(
+                    () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(62),
+                    () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(2_150)
+            );
+        }
+
+        @Test
+        void distance66() {
+            ExtractableResponse<Response> response = 경로_조회_요청(교대역, 사당역, SearchType.DURATION.name());
+
+            assertAll(
+                    () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(66),
+                    () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(2_250)
+            );
+        }
+    }
+
+    private Long 지하철_노선_생성_요청(String name, String color, Long upStation, Long downStation, int distance, int duration) {
+        Map<String, String> lineCreateParams;
+        lineCreateParams = new HashMap<>();
+        lineCreateParams.put("name", name);
+        lineCreateParams.put("color", color);
+        lineCreateParams.put("upStationId", upStation + "");
+        lineCreateParams.put("downStationId", downStation + "");
+        lineCreateParams.put("distance", distance + "");
+        lineCreateParams.put("duration", duration + "");
+
+        return LineSteps.지하철_노선_생성_요청(lineCreateParams).jsonPath().getLong("id");
+    }
+}

--- a/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
@@ -14,6 +14,7 @@ import static nextstep.subway.acceptance.LineSteps.지하철_노선에_지하철
 import static nextstep.subway.acceptance.PathSteps.경로_조회_요청;
 import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("지하철 경로 검색")
 class PathAcceptanceTest extends AcceptanceTest {
@@ -26,11 +27,16 @@ class PathAcceptanceTest extends AcceptanceTest {
     private Long 삼호선;
 
     /**
-     * 교대역    --- *2호선* ---   강남역
-     * |                        |
-     * *3호선*                   *신분당선*
-     * |                        |
-     * 남부터미널역  --- *3호선* ---   양재
+     * Given 지하철역이 등록되어있음
+     * And 지하철 노선이 등록되어있음
+     * And 지하철 노선에 지하철역이 등록되어있음
+     *
+     * <이동거리|이동시간>
+     * 교대역    --- *2호선* <10|10> ---   강남역
+     * |                                    |
+     * *3호선* <2|2>                       *신분당선* <10|10>
+     * |                                    |
+     * 남부터미널역  --- *3호선* <3|3> ---   양재역
      */
     @BeforeEach
     public void setUp() {
@@ -48,6 +54,16 @@ class PathAcceptanceTest extends AcceptanceTest {
         지하철_노선에_지하철_구간_생성_요청(삼호선, createSectionCreateParams(남부터미널역, 양재역, 3, 3));
     }
 
+
+    /**
+     * Feature: 지하철 경로 검색
+     *
+     *   Scenario: 두 역의 최단 거리 경로를 조회
+     *     When 출발역에서 도착역까지의 최단 거리 경로 조회를 요청
+     *     Then 최단 거리 경로를 응답
+     *     And 총 거리와 소요 시간을 함께 응답함
+     *     And 지하철 이용 요금도 함께 응답함
+     */
     @DisplayName("두 역의 최단 거리 경로를 조회한다.")
     @Test
     void findPathByDistance() {
@@ -55,26 +71,34 @@ class PathAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> response = 경로_조회_요청(교대역, 양재역, SearchType.DISTANCE.name());
 
         // then
-        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(교대역, 남부터미널역, 양재역);
+        assertAll(
+                () -> assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(교대역, 남부터미널역, 양재역),
+                () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(5),
+                () -> assertThat(response.jsonPath().getInt("duration")).isEqualTo(5),
+                () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(1_250)
+        );
     }
 
     /**
      * Feature: 지하철 경로 검색
      *
      *   Scenario: 두 역의 최소 시간 경로를 조회
-     *     Given 지하철역이 등록되어있음
-     *     And 지하철 노선이 등록되어있음
-     *     And 지하철 노선에 지하철역이 등록되어있음
      *     When 출발역에서 도착역까지의 최소 시간 기준으로 경로 조회를 요청
      *     Then 최소 시간 기준 경로를 응답
      *     And 총 거리와 소요 시간을 함께 응답함
+     *     And 지하철 이용 요금도 함께 응답함
      */
     @DisplayName("두 역의 최소 시간 경로를 조회한다.")
     @Test
     void findPathByDuration() {
         ExtractableResponse<Response> response = 경로_조회_요청(교대역, 양재역, SearchType.DURATION.name());
 
-        assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(교대역, 남부터미널역, 양재역);
+        assertAll(
+                () -> assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(교대역, 남부터미널역, 양재역),
+                () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(5),
+                () -> assertThat(response.jsonPath().getInt("duration")).isEqualTo(5),
+                () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(1_250)
+        );
     }
 
     private Long 지하철_노선_생성_요청(String name, String color, Long upStation, Long downStation, int distance, int duration) {

--- a/src/test/java/nextstep/subway/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/documentation/PathDocumentation.java
@@ -65,7 +65,8 @@ public class PathDocumentation extends Documentation {
                                 fieldWithPath("stations[].id").type(JsonFieldType.NUMBER).description("지하철 역 id"),
                                 fieldWithPath("stations[].name").type(JsonFieldType.STRING).description("지하철 역 이름"),
                                 fieldWithPath("distance").type(JsonFieldType.NUMBER).description("경로의 이동거리"),
-                                fieldWithPath("duration").type(JsonFieldType.NUMBER).description("경로의 이동시간")
+                                fieldWithPath("duration").type(JsonFieldType.NUMBER).description("경로의 이동시간"),
+                                fieldWithPath("fare").type(JsonFieldType.NUMBER).description("지하철 이용요금")
                         )
                 ));
     }

--- a/src/test/java/nextstep/subway/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/documentation/PathDocumentation.java
@@ -41,7 +41,7 @@ public class PathDocumentation extends Documentation {
                 Lists.newArrayList(
                         new StationResponse(SOURCE_ID, "강남역"),
                         new StationResponse(TARGET_ID, "역삼역")
-                ), 10, 10);
+                ), 10, 10, 1_250);
         when(pathService.findPath(anyLong(), anyLong(), any(SearchType.class))).thenReturn(pathResponse);
 
         // When

--- a/src/test/java/nextstep/subway/unit/FarePolicyTest.java
+++ b/src/test/java/nextstep/subway/unit/FarePolicyTest.java
@@ -1,0 +1,24 @@
+package nextstep.subway.unit;
+
+import nextstep.subway.domain.FarePolicy;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FarePolicyTest {
+
+    @ParameterizedTest
+    @CsvSource({
+            "9,1_250",
+            "10,1_250",
+            "11,1_350",
+
+            "49,2_050",
+            "50,2_050",
+            "51,2_150",
+    })
+    void calculate(int distance, int fare) {
+        assertThat(FarePolicy.calculate(distance)).isEqualTo(fare);
+    }
+}

--- a/src/test/java/nextstep/subway/unit/PathTest.java
+++ b/src/test/java/nextstep/subway/unit/PathTest.java
@@ -1,0 +1,47 @@
+package nextstep.subway.unit;
+
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Path;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.Sections;
+import nextstep.subway.domain.Station;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyInt;
+
+class PathTest {
+
+    private Station 강남역;
+    private Station 역삼역;
+    private Line 이호선;
+    private Sections sections;
+
+    @BeforeEach
+    void setUp() {
+        강남역 = new Station("강남역");
+        역삼역 = new Station("역삼역");
+        이호선 = new Line("2호선", "green");
+    }
+
+    @ParameterizedTest
+    @CsvSource({
+            "9,1_250",
+            "10,1_250",
+            "11,1_350",
+
+            "49,2_050",
+            "50,2_050",
+            "51,2_150",
+    })
+    void extractFare(int distance, int fare) {
+        sections = new Sections(List.of(new Section(이호선, 강남역, 역삼역, distance, anyInt())));
+        Path path = new Path(sections);
+
+        assertThat(path.extractFare()).isEqualTo(fare);
+    }
+}


### PR DESCRIPTION
안녕하세요 성현님! 많이 늦어졌네요
작업은 많이한것 같은데, 결과물은 간단해보이네요 :)

---

지난번 미션에서 3개의 코멘트 주신 부분은 고민해 봤습니다. 아리송한 부분이 많아서 본 미션에서 적용은 하지 않았습니다. 

## https://github.com/next-step/atdd-subway-fare/pull/264#discussion_r1119868885
>  identifier만 주입 받을 수 있다면 해당 부분을 Documentation에 위치해서 재사용 할 수 있을 것 같음

해당 코멘트는 어떤 의도로 코멘트 해주신 것인지 이해가 가지 않습니다. 😭
경로 조회 타입 추가 미션에서 PathDocumentation클래스로 하나의 API만 문서화 한다는 것으로 생각해서 documentConfig() 메서드로써 추출했습니다. 하지만 같은 클래스에서도 여러 API를 문서화 할 수 있고, filter들(requestParameters 나 responseFields 등) 이 계속 변할 거라 생각됩니다. 즉 filter 때문에 자식 클래스에서 갖고있어야 한다고 생각이 됩니다~!

## https://github.com/next-step/atdd-subway-fare/pull/264#discussion_r1119874568
> SubwayMap 과 SearchType의 관계에서
생성자를 통해 의존을 맺는 것과 메서드 파라미터를 통해 의존을 맺는 경우를 비교했을 때 어떤 방법이 의존을 약하게 맺어주는 방법일까요?

물론 파라미터를 통해 의존은 맺는 경우가 영구적 의존이 아니라 협력시점의 일시적 의존으로써 의존 관계가 약할 수 있지만 해당 클래스에서는 graph가 그려져 있어야만 하더라구요! 물론 타입에 대해서 모두 그려둘수도 있겠지만 그러지 않고 생성자로써 graph의 가중치를 고정한 형태로 구현했습니다!

## https://github.com/next-step/atdd-subway-fare/pull/264#discussion_r1119878445
> 테스트 픽스쳐를 사용한 변경 범위 최소화

테스트 픽스처를 보통 팩토리패턴으로 구현하는 것 같습니다. (?!)
지하철 역에 대해서는 좋은 것 같은데, 지하철 노선의 경우 디테일한 인자들을 달고다니는데요
```
이호선 = 지하철_노선_생성_요청("2호선", "green", 교대역, 강남역, 10, 10);
신분당선 = 지하철_노선_생성_요청("신분당선", "red", 강남역, 양재역, 10, 10);
삼호선 = 지하철_노선_생성_요청("3호선", "orange", 교대역, 남부터미널역, 2, 2);
```
```
class SubwayFactory {
    public static Long createStation(String name) {
        return 지하철역_생성_요청(관리자, name).jsonPath().getLong("id");
    }
    // ...
}
```
지하철 노선도 팩토리패턴으로 구현하자니, 클라이언트에서 지하철 역과 같이 이름만으로 만들 수는 없고 생성자에 의존하게 되더라구요.
어떻게 구현하는 것이 best pracitce일까요?

아래와 같이 테스트용 이호선, 신분당선, 삼호선 생성 메서드를 구성하는 것도 방법일까요? 뭔진 모르겠지만, 뭔가 손이 가진 않는 방법이라서요..
```
class SubwayFactory {
    // ...
    public static Long create이호선() {
        return 지하철_노선_생성_요청("2호선", "green", 교대역, 강남역, 10, 10).jsonPath().getLong("id");
    }
}
```
