### PR TITLE
요금 정책 추가 미션

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -11,4 +11,4 @@
 
 === 경로 조회
 
-operation::path[snippets='http-request,request-parameters,http-response,response-fields']
+operation::path[snippets='http-request,request-headers,request-parameters,http-response,response-fields']

--- a/src/main/java/nextstep/member/AnonymousAuthenticationFilter.java
+++ b/src/main/java/nextstep/member/AnonymousAuthenticationFilter.java
@@ -1,0 +1,47 @@
+package nextstep.member;
+
+import nextstep.member.application.JwtTokenProvider;
+import nextstep.member.context.SecurityContextHolder;
+import nextstep.member.domain.AnonymousUser;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.List;
+
+public class AnonymousAuthenticationFilter implements Filter {
+    private final String principal = AnonymousUser.PRINCIPAL;
+    private final List<String> roleType = AnonymousUser.ROLES;
+
+    private final JwtTokenProvider jwtTokenProvider = new JwtTokenProvider();
+
+    /**
+     * 스프링 시큐리티에서는 security context 내부의 Authentication에 익명사용자에 대한 authorization을 등록한다.
+     * 하지만 편의를 위해 간략화 한다. -> SecurityContextHolder의 SecurityContext의 Authentication필드에 익명사용자용 토큰을 등록한다.
+     */
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest) request;
+
+        String authorization = httpRequest.getHeader("Authorization");
+
+        if (!StringUtils.hasText(authorization)) {
+            SecurityContextHolder securityContextHolder = new SecurityContextHolder();
+            securityContextHolder.setContext(createAnonymousAuthentication());
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * 익명사용자에 대한 authorization에는 IP정보 등을 담는 것으로 보이지만, 익명사용자의 지정 principal, roleType만으로 토큰화한다.
+     */
+    protected String createAnonymousAuthentication() {
+        return jwtTokenProvider.createToken(principal, roleType);
+    }
+}

--- a/src/main/java/nextstep/member/AnonymousAuthenticationFilter.java
+++ b/src/main/java/nextstep/member/AnonymousAuthenticationFilter.java
@@ -3,6 +3,7 @@ package nextstep.member;
 import nextstep.member.application.JwtTokenProvider;
 import nextstep.member.context.SecurityContextHolder;
 import nextstep.member.domain.AnonymousUser;
+import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
 import javax.servlet.Filter;
@@ -14,11 +15,16 @@ import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.List;
 
+@Component
 public class AnonymousAuthenticationFilter implements Filter {
     private final String principal = AnonymousUser.PRINCIPAL;
     private final List<String> roleType = AnonymousUser.ROLES;
 
-    private final JwtTokenProvider jwtTokenProvider = new JwtTokenProvider();
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public AnonymousAuthenticationFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
 
     /**
      * 스프링 시큐리티에서는 security context 내부의 Authentication에 익명사용자에 대한 authorization을 등록한다.

--- a/src/main/java/nextstep/member/application/MemberService.java
+++ b/src/main/java/nextstep/member/application/MemberService.java
@@ -17,18 +17,22 @@ public class MemberService {
         this.memberRepository = memberRepository;
     }
 
+    public Member getMember(Long id) {
+        return memberRepository.findById(id).orElseThrow(RuntimeException::new);
+    }
+
     public MemberResponse createMember(MemberRequest request) {
         Member member = memberRepository.save(request.toMember());
         return MemberResponse.of(member);
     }
 
     public MemberResponse findMember(Long id) {
-        Member member = memberRepository.findById(id).orElseThrow(RuntimeException::new);
+        Member member = getMember(id);
         return MemberResponse.of(member);
     }
 
     public void updateMember(Long id, MemberRequest param) {
-        Member member = memberRepository.findById(id).orElseThrow(RuntimeException::new);
+        Member member = getMember(id);
         member.update(param.toMember());
     }
 

--- a/src/main/java/nextstep/member/context/SecurityContext.java
+++ b/src/main/java/nextstep/member/context/SecurityContext.java
@@ -1,0 +1,13 @@
+package nextstep.member.context;
+
+public class SecurityContext {
+
+    private String authentication;
+    public void setAuthentication(String token) {
+        authentication = token;
+    }
+
+    public String getAuthentication() {
+        return authentication;
+    }
+}

--- a/src/main/java/nextstep/member/context/SecurityContextHolder.java
+++ b/src/main/java/nextstep/member/context/SecurityContextHolder.java
@@ -1,0 +1,13 @@
+package nextstep.member.context;
+
+public class SecurityContextHolder  {
+    private static SecurityContext context = new SecurityContext();
+
+    public void setContext(String token) {
+        context.setAuthentication(token);
+    }
+
+    public static SecurityContext getContext() {
+        return context;
+    }
+}

--- a/src/main/java/nextstep/member/domain/AnonymousUser.java
+++ b/src/main/java/nextstep/member/domain/AnonymousUser.java
@@ -1,0 +1,8 @@
+package nextstep.member.domain;
+
+import java.util.List;
+
+public class AnonymousUser extends AuthenticatedUser {
+    public static final String PRINCIPAL = Long.toString(-1L);
+    public static final List<String> ROLES = List.of(RoleType.ROLE_ANONYMOUS.name());
+}

--- a/src/main/java/nextstep/member/domain/AuthenticatedUser.java
+++ b/src/main/java/nextstep/member/domain/AuthenticatedUser.java
@@ -1,0 +1,4 @@
+package nextstep.member.domain;
+
+public abstract class AuthenticatedUser {
+}

--- a/src/main/java/nextstep/member/domain/AuthenticationPrincipal.java
+++ b/src/main/java/nextstep/member/domain/AuthenticationPrincipal.java
@@ -8,4 +8,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface AuthenticationPrincipal {
+    boolean required() default true;
 }

--- a/src/main/java/nextstep/member/domain/LoginMember.java
+++ b/src/main/java/nextstep/member/domain/LoginMember.java
@@ -5,15 +5,21 @@ import java.util.Objects;
 
 public class LoginMember extends AuthenticatedUser {
     private Long id;
+    private int age;
     private List<String> roles;
 
-    public LoginMember(Long id, List<String> roles) {
+    public LoginMember(Long id, int age, List<String> roles) {
         this.id = id;
+        this.age = age;
         this.roles = roles;
     }
 
     public Long getId() {
         return id;
+    }
+
+    public int getAge() {
+        return age;
     }
 
     public List<String> getRoles() {
@@ -29,11 +35,11 @@ public class LoginMember extends AuthenticatedUser {
             return false;
         }
         LoginMember that = (LoginMember) o;
-        return Objects.equals(id, that.id) && Objects.equals(roles, that.roles);
+        return Objects.equals(id, that.id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(id, roles);
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/nextstep/member/domain/LoginMember.java
+++ b/src/main/java/nextstep/member/domain/LoginMember.java
@@ -1,8 +1,9 @@
 package nextstep.member.domain;
 
 import java.util.List;
+import java.util.Objects;
 
-public class LoginMember {
+public class LoginMember extends AuthenticatedUser {
     private Long id;
     private List<String> roles;
 
@@ -17,5 +18,22 @@ public class LoginMember {
 
     public List<String> getRoles() {
         return roles;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        LoginMember that = (LoginMember) o;
+        return Objects.equals(id, that.id) && Objects.equals(roles, that.roles);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id, roles);
     }
 }

--- a/src/main/java/nextstep/member/domain/RoleType.java
+++ b/src/main/java/nextstep/member/domain/RoleType.java
@@ -2,5 +2,6 @@ package nextstep.member.domain;
 
 public enum RoleType {
     ROLE_ADMIN,
-    ROLE_MEMBER
+    ROLE_MEMBER,
+    ROLE_ANONYMOUS
 }

--- a/src/main/java/nextstep/member/ui/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/nextstep/member/ui/AuthenticationPrincipalArgumentResolver.java
@@ -1,10 +1,13 @@
 package nextstep.member.ui;
 
 import nextstep.member.application.JwtTokenProvider;
+import nextstep.member.context.SecurityContextHolder;
+import nextstep.member.domain.AnonymousUser;
 import nextstep.member.domain.AuthenticationPrincipal;
 import nextstep.member.domain.LoginMember;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.support.WebDataBinderFactory;
 import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
@@ -27,7 +30,34 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
 
     @Override
     public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) throws Exception {
+        boolean required = parameter.getParameterAnnotation(AuthenticationPrincipal.class).required();
         String authorization = webRequest.getHeader("Authorization");
+
+        if (required) {
+            if (StringUtils.hasText(authorization)) {
+                return getLoginMember(authorization);
+            }
+        }
+
+        if (!required) {
+            if (StringUtils.hasText(authorization)) {
+                return getLoginMember(authorization);
+            } else {
+                return getAnonymousUser();
+            }
+        }
+
+        throw new RuntimeException();
+    }
+
+    private AnonymousUser getAnonymousUser() {
+        String anonymousToken = SecurityContextHolder.getContext().getAuthentication();
+        jwtTokenProvider.validateToken(anonymousToken);
+
+        return new AnonymousUser();
+    }
+
+    private LoginMember getLoginMember(String authorization) {
         if (!"bearer".equalsIgnoreCase(authorization.split(" ")[0])) {
             throw new AuthenticationException();
         }

--- a/src/main/java/nextstep/member/ui/AuthenticationPrincipalArgumentResolver.java
+++ b/src/main/java/nextstep/member/ui/AuthenticationPrincipalArgumentResolver.java
@@ -1,10 +1,12 @@
 package nextstep.member.ui;
 
 import nextstep.member.application.JwtTokenProvider;
+import nextstep.member.application.MemberService;
 import nextstep.member.context.SecurityContextHolder;
 import nextstep.member.domain.AnonymousUser;
 import nextstep.member.domain.AuthenticationPrincipal;
 import nextstep.member.domain.LoginMember;
+import nextstep.member.domain.Member;
 import org.springframework.core.MethodParameter;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
@@ -13,14 +15,14 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-import java.util.List;
-
 @Component
 public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArgumentResolver {
-    private JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenProvider jwtTokenProvider;
+    private final MemberService memberService;
 
-    public AuthenticationPrincipalArgumentResolver(JwtTokenProvider jwtTokenProvider) {
+    public AuthenticationPrincipalArgumentResolver(JwtTokenProvider jwtTokenProvider, MemberService memberService) {
         this.jwtTokenProvider = jwtTokenProvider;
+        this.memberService = memberService;
     }
 
     @Override
@@ -64,8 +66,7 @@ public class AuthenticationPrincipalArgumentResolver implements HandlerMethodArg
         String token = authorization.split(" ")[1];
 
         Long id = Long.parseLong(jwtTokenProvider.getPrincipal(token));
-        List<String> roles = jwtTokenProvider.getRoles(token);
-
-        return new LoginMember(id, roles);
+        Member member = memberService.getMember(id);
+        return new LoginMember(member.getId(), member.getAge(), member.getRoles());
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/FareCalculator.java
+++ b/src/main/java/nextstep/subway/applicaion/FareCalculator.java
@@ -6,10 +6,8 @@ import nextstep.subway.domain.AgeFarePolicy;
 import nextstep.subway.domain.DistanceFarePolicy;
 import nextstep.subway.domain.LineSurchargePolicy;
 import nextstep.subway.domain.Path;
-import org.springframework.stereotype.Service;
 
-@Service
-public class FareService {
+public class FareCalculator {
 
     /**
      * 요금 정책

--- a/src/main/java/nextstep/subway/applicaion/FareService.java
+++ b/src/main/java/nextstep/subway/applicaion/FareService.java
@@ -1,0 +1,59 @@
+package nextstep.subway.applicaion;
+
+import nextstep.member.application.MemberService;
+import nextstep.member.domain.AuthenticatedUser;
+import nextstep.member.domain.LoginMember;
+import nextstep.subway.domain.AgeFarePolicy;
+import nextstep.subway.domain.DistanceFarePolicy;
+import nextstep.subway.domain.LineSurchargePolicy;
+import nextstep.subway.domain.Path;
+import org.springframework.stereotype.Service;
+
+@Service
+public class FareService {
+
+    private final MemberService memberService;
+
+    public FareService(MemberService memberService) {
+        this.memberService = memberService;
+    }
+
+    /**
+     * 요금 정책
+     *
+     * 1. 추가 거리별 추가 운임
+     * 2. 이용 노선 중 가장 큰 추가 운임
+     * 3. 최종 금액에서 나이별 할인
+     */
+    public int getTotalFare(AuthenticatedUser user, Path path) {
+        int totalFare = 0;
+
+        // 1. 추가 거리별 추가 운임
+        totalFare += getCalculatedDistanceFare(path);
+
+        // 2. 이용 노선 중 가장 큰 추가 운임
+        totalFare += getCalculatedHighestSurcharge(path);
+
+        // 3. 최종 금액에서 나이별 할인
+        totalFare = getCalculatedAgeFare(totalFare, user);
+
+        return totalFare;
+    }
+
+    private int getCalculatedDistanceFare(Path path) {
+        int distance = path.extractDistance();
+        return DistanceFarePolicy.calculate(distance);
+    }
+
+    private int getCalculatedHighestSurcharge(Path path) {
+        return LineSurchargePolicy.calculate(path);
+    }
+
+    private int getCalculatedAgeFare(int fare, AuthenticatedUser user) {
+        int age = -1;
+        if (user instanceof LoginMember) {
+            age = memberService.findMember(((LoginMember) user).getId()).getAge();
+        }
+        return AgeFarePolicy.calculate(fare, age);
+    }
+}

--- a/src/main/java/nextstep/subway/applicaion/FareService.java
+++ b/src/main/java/nextstep/subway/applicaion/FareService.java
@@ -1,6 +1,5 @@
 package nextstep.subway.applicaion;
 
-import nextstep.member.application.MemberService;
 import nextstep.member.domain.AuthenticatedUser;
 import nextstep.member.domain.LoginMember;
 import nextstep.subway.domain.AgeFarePolicy;
@@ -11,12 +10,6 @@ import org.springframework.stereotype.Service;
 
 @Service
 public class FareService {
-
-    private final MemberService memberService;
-
-    public FareService(MemberService memberService) {
-        this.memberService = memberService;
-    }
 
     /**
      * 요금 정책
@@ -52,7 +45,8 @@ public class FareService {
     private int getCalculatedAgeFare(int fare, AuthenticatedUser user) {
         int age = -1;
         if (user instanceof LoginMember) {
-            age = memberService.findMember(((LoginMember) user).getId()).getAge();
+            LoginMember loginMember = (LoginMember) user;
+            age = loginMember.getAge();
         }
         return AgeFarePolicy.calculate(fare, age);
     }

--- a/src/main/java/nextstep/subway/applicaion/LineService.java
+++ b/src/main/java/nextstep/subway/applicaion/LineService.java
@@ -26,7 +26,7 @@ public class LineService {
 
     @Transactional
     public LineResponse saveLine(LineRequest request) {
-        Line line = lineRepository.save(new Line(request.getName(), request.getColor()));
+        Line line = lineRepository.save(new Line(request.getName(), request.getColor(), request.getSurcharge()));
         if (request.getUpStationId() != null && request.getDownStationId() != null && request.getDistance() != 0) {
             Station upStation = stationService.findById(request.getUpStationId());
             Station downStation = stationService.findById(request.getDownStationId());

--- a/src/main/java/nextstep/subway/applicaion/PathService.java
+++ b/src/main/java/nextstep/subway/applicaion/PathService.java
@@ -1,5 +1,6 @@
 package nextstep.subway.applicaion;
 
+import nextstep.member.domain.AuthenticatedUser;
 import nextstep.subway.applicaion.dto.PathResponse;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Path;
@@ -20,14 +21,13 @@ public class PathService {
         this.stationService = stationService;
     }
 
-    public PathResponse findPath(Long source, Long target, SearchType searchType) {
+    public PathResponse findPath(AuthenticatedUser user, Long source, Long target, SearchType searchType) {
         Station departureStation = stationService.findById(source);
         Station destinationStation = stationService.findById(target);
         List<Line> lines = lineService.findLines();
 
         SubwayMap subwayMap = new SubwayMap(lines, searchType);
         Path path = subwayMap.findPath(departureStation, destinationStation);
-
         return PathResponse.of(path);
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/PathService.java
+++ b/src/main/java/nextstep/subway/applicaion/PathService.java
@@ -13,21 +13,31 @@ import java.util.List;
 
 @Service
 public class PathService {
-    private LineService lineService;
-    private StationService stationService;
+    private final LineService lineService;
+    private final StationService stationService;
+    private final FareService fareService;
 
-    public PathService(LineService lineService, StationService stationService) {
+    public PathService(LineService lineService, StationService stationService, FareService fareService) {
         this.lineService = lineService;
         this.stationService = stationService;
+        this.fareService = fareService;
     }
 
     public PathResponse findPath(AuthenticatedUser user, Long source, Long target, SearchType searchType) {
+        Path path = getPath(source, target, searchType);
+
+        int totalFare = fareService.getTotalFare(user, path);
+
+        return PathResponse.of(path, totalFare);
+    }
+
+    private Path getPath(Long source, Long target, SearchType searchType) {
         Station departureStation = stationService.findById(source);
         Station destinationStation = stationService.findById(target);
         List<Line> lines = lineService.findLines();
 
         SubwayMap subwayMap = new SubwayMap(lines, searchType);
         Path path = subwayMap.findPath(departureStation, destinationStation);
-        return PathResponse.of(path);
+        return path;
     }
 }

--- a/src/main/java/nextstep/subway/applicaion/PathService.java
+++ b/src/main/java/nextstep/subway/applicaion/PathService.java
@@ -15,18 +15,17 @@ import java.util.List;
 public class PathService {
     private final LineService lineService;
     private final StationService stationService;
-    private final FareService fareService;
+    private final FareCalculator fareCalculator = new FareCalculator();
 
-    public PathService(LineService lineService, StationService stationService, FareService fareService) {
+    public PathService(LineService lineService, StationService stationService) {
         this.lineService = lineService;
         this.stationService = stationService;
-        this.fareService = fareService;
     }
 
     public PathResponse findPath(AuthenticatedUser user, Long source, Long target, SearchType searchType) {
         Path path = getPath(source, target, searchType);
 
-        int totalFare = fareService.getTotalFare(user, path);
+        int totalFare = fareCalculator.getTotalFare(user, path);
 
         return PathResponse.of(path, totalFare);
     }

--- a/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/LineRequest.java
@@ -3,6 +3,7 @@ package nextstep.subway.applicaion.dto;
 public class LineRequest {
     private String name;
     private String color;
+    private int surcharge;
     private Long upStationId;
     private Long downStationId;
     private int distance;
@@ -15,6 +16,10 @@ public class LineRequest {
 
     public String getColor() {
         return color;
+    }
+
+    public int getSurcharge() {
+        return surcharge;
     }
 
     public Long getUpStationId() {

--- a/src/main/java/nextstep/subway/applicaion/dto/PathResponse.java
+++ b/src/main/java/nextstep/subway/applicaion/dto/PathResponse.java
@@ -18,13 +18,12 @@ public class PathResponse {
         this.fare = fare;
     }
 
-    public static PathResponse of(Path path) {
+    public static PathResponse of(Path path, int fare) {
         List<StationResponse> stations = path.getStations().stream()
                 .map(StationResponse::of)
                 .collect(Collectors.toList());
         int distance = path.extractDistance();
         int duration = path.extractDuration();
-        int fare = path.extractFare();
 
         return new PathResponse(stations, distance, duration, fare);
     }

--- a/src/main/java/nextstep/subway/domain/AgeFarePolicy.java
+++ b/src/main/java/nextstep/subway/domain/AgeFarePolicy.java
@@ -1,0 +1,47 @@
+package nextstep.subway.domain;
+
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.function.IntPredicate;
+import java.util.function.IntUnaryOperator;
+
+public enum AgeFarePolicy {
+    CHILDREN(
+            age -> 6 <= age && age < 13,
+            fare -> discount(fare, 50)
+    ),
+    TEENAGER(
+            age -> 13 <= age && age < 19,
+            fare -> discount(fare, 20)
+    )
+    ;
+    private final IntPredicate ageRange;
+    private final IntUnaryOperator discountOperator;
+
+    AgeFarePolicy(IntPredicate ageRange, IntUnaryOperator discountOperator) {
+        this.ageRange = ageRange;
+        this.discountOperator = discountOperator;
+    }
+
+    public static int calculate(int fare, int age) {
+        Optional<AgeFarePolicy> ageFarePolicy = findPolicy(age);
+
+        if (ageFarePolicy.isEmpty()) {
+            return fare;
+        }
+        return ageFarePolicy.get()
+                .discountOperator.applyAsInt(fare);
+    }
+
+    private static Optional<AgeFarePolicy> findPolicy(int age) {
+        Optional<AgeFarePolicy> ageFarePolicy = Arrays.stream(values())
+                .filter(it -> it.ageRange.test(age))
+                .findFirst();
+        return ageFarePolicy;
+    }
+
+    private static int discount(int fare, int discountPercentage) {
+        double discountedRatio = 1.0 - (discountPercentage / 100.0);
+        return (int) (fare * discountedRatio);
+    }
+}

--- a/src/main/java/nextstep/subway/domain/DistanceFarePolicy.java
+++ b/src/main/java/nextstep/subway/domain/DistanceFarePolicy.java
@@ -4,7 +4,7 @@ import java.util.Arrays;
 import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
-public enum FarePolicy {
+public enum DistanceFarePolicy {
     NOT_MORE_THAN_10KM(
             distance -> distance <= Constants.TEN_KM,
             distance -> 0
@@ -22,7 +22,7 @@ public enum FarePolicy {
     private final Predicate<Integer> predicate;
     private final UnaryOperator<Integer> extraFareOperator;
 
-    FarePolicy(Predicate<Integer> predicate, UnaryOperator<Integer> extraFareOperator) {
+    DistanceFarePolicy(Predicate<Integer> predicate, UnaryOperator<Integer> extraFareOperator) {
         this.predicate = predicate;
         this.extraFareOperator = extraFareOperator;
     }

--- a/src/main/java/nextstep/subway/domain/FarePolicy.java
+++ b/src/main/java/nextstep/subway/domain/FarePolicy.java
@@ -5,7 +5,7 @@ import java.util.function.Predicate;
 import java.util.function.UnaryOperator;
 
 public enum FarePolicy {
-    NOT_MORE_THAN_10KM (
+    NOT_MORE_THAN_10KM(
             distance -> distance <= Constants.TEN_KM,
             distance -> 0
     ),
@@ -40,6 +40,14 @@ public enum FarePolicy {
         return extraFare;
     }
 
+    /**
+     * 추가 운임에 대한 거리에 따른 계산 메서드
+     *
+     * @param start 시작 위치
+     * @param end   도착 위치
+     * @param unit  추가 운임의 단위거리
+     * @return 거리에 따른 추가운임
+     */
     private static int calculateExtraFare(int start, int end, int unit) {
         return (int) ((Math.ceil((end - start - 1) / unit) + 1) * 100);
     }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -40,6 +40,10 @@ public class Line {
         return color;
     }
 
+    public int getSurcharge() {
+        return surcharge;
+    }
+
     public List<Section> getSections() {
         return sections.getSections();
     }

--- a/src/main/java/nextstep/subway/domain/Line.java
+++ b/src/main/java/nextstep/subway/domain/Line.java
@@ -14,6 +14,7 @@ public class Line {
     private Long id;
     private String name;
     private String color;
+    private int surcharge;
 
     @Embedded
     private Sections sections = new Sections();
@@ -21,9 +22,10 @@ public class Line {
     public Line() {
     }
 
-    public Line(String name, String color) {
+    public Line(String name, String color, int surcharge) {
         this.name = name;
         this.color = color;
+        this.surcharge = surcharge;
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/subway/domain/LineSurchargePolicy.java
+++ b/src/main/java/nextstep/subway/domain/LineSurchargePolicy.java
@@ -1,0 +1,8 @@
+package nextstep.subway.domain;
+
+public class LineSurchargePolicy {
+
+    public static int calculate(Path path) {
+        return path.getSections().getMaxSurcharge();
+    }
+}

--- a/src/main/java/nextstep/subway/domain/Path.java
+++ b/src/main/java/nextstep/subway/domain/Path.java
@@ -26,6 +26,11 @@ public class Path {
     }
 
     public int extractFare() {
-        return FarePolicy.calculate(extractDistance());
+        int totalFare = 0;
+
+        totalFare += FarePolicy.calculate(extractDistance());
+        totalFare += sections.getMaxSurcharge();
+
+        return totalFare;
     }
 }

--- a/src/main/java/nextstep/subway/domain/Path.java
+++ b/src/main/java/nextstep/subway/domain/Path.java
@@ -24,13 +24,4 @@ public class Path {
     public List<Station> getStations() {
         return sections.getStations();
     }
-
-    public int extractFare() {
-        int totalFare = 0;
-
-        totalFare += DistanceFarePolicy.calculate(extractDistance());
-        totalFare += sections.getMaxSurcharge();
-
-        return totalFare;
-    }
 }

--- a/src/main/java/nextstep/subway/domain/Path.java
+++ b/src/main/java/nextstep/subway/domain/Path.java
@@ -28,7 +28,7 @@ public class Path {
     public int extractFare() {
         int totalFare = 0;
 
-        totalFare += FarePolicy.calculate(extractDistance());
+        totalFare += DistanceFarePolicy.calculate(extractDistance());
         totalFare += sections.getMaxSurcharge();
 
         return totalFare;

--- a/src/main/java/nextstep/subway/domain/Sections.java
+++ b/src/main/java/nextstep/subway/domain/Sections.java
@@ -171,4 +171,11 @@ public class Sections {
     public int totalDuration() {
         return sections.stream().mapToInt(Section::getDuration).sum();
     }
+
+    public int getMaxSurcharge() {
+        return sections.stream()
+                .mapToInt(section -> section.getLine().getSurcharge())
+                .max()
+                .orElse(0);
+    }
 }

--- a/src/main/java/nextstep/subway/ui/PathController.java
+++ b/src/main/java/nextstep/subway/ui/PathController.java
@@ -20,6 +20,6 @@ public class PathController {
 
     @GetMapping("/paths")
     public ResponseEntity<PathResponse> findPath(@AuthenticationPrincipal(required = false) AuthenticatedUser user, @RequestParam Long source, @RequestParam Long target, @RequestParam SearchType type) {
-        return ResponseEntity.ok(pathService.findPath(source, target, type));
+        return ResponseEntity.ok(pathService.findPath(user, source, target, type));
     }
 }

--- a/src/main/java/nextstep/subway/ui/PathController.java
+++ b/src/main/java/nextstep/subway/ui/PathController.java
@@ -1,5 +1,7 @@
 package nextstep.subway.ui;
 
+import nextstep.member.domain.AuthenticatedUser;
+import nextstep.member.domain.AuthenticationPrincipal;
 import nextstep.subway.applicaion.PathService;
 import nextstep.subway.applicaion.dto.PathResponse;
 import nextstep.subway.domain.SearchType;
@@ -17,7 +19,7 @@ public class PathController {
     }
 
     @GetMapping("/paths")
-    public ResponseEntity<PathResponse> findPath(@RequestParam Long source, @RequestParam Long target, @RequestParam SearchType type) {
+    public ResponseEntity<PathResponse> findPath(@AuthenticationPrincipal(required = false) AuthenticatedUser user, @RequestParam Long source, @RequestParam Long target, @RequestParam SearchType type) {
         return ResponseEntity.ok(pathService.findPath(source, target, type));
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/AuthAcceptanceTest.java
@@ -12,7 +12,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class AuthAcceptanceTest extends AcceptanceTest {
 
-
     @DisplayName("Bearer Auth")
     @Test
     void bearerAuth() {

--- a/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/LineAcceptanceTest.java
@@ -26,7 +26,7 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void createLine() {
         // when
-        ExtractableResponse<Response> response = 지하철_노선_생성_요청("2호선", "green");
+        ExtractableResponse<Response> response = 지하철_노선_생성_요청("2호선", "green", 0);
 
         // then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
@@ -44,8 +44,8 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLines() {
         // given
-        지하철_노선_생성_요청("2호선", "green");
-        지하철_노선_생성_요청("3호선", "orange");
+        지하철_노선_생성_요청("2호선", "green", 0);
+        지하철_노선_생성_요청("3호선", "orange", 500);
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_목록_조회_요청();
@@ -64,7 +64,7 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void getLine() {
         // given
-        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green");
+        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green", 0);
 
         // when
         ExtractableResponse<Response> response = 지하철_노선_조회_요청(createResponse);
@@ -83,7 +83,7 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void updateLine() {
         // given
-        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green");
+        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green", 0);
 
         // when
         Map<String, String> params = new HashMap<>();
@@ -110,7 +110,7 @@ class LineAcceptanceTest extends AcceptanceTest {
     @Test
     void deleteLine() {
         // given
-        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green");
+        ExtractableResponse<Response> createResponse = 지하철_노선_생성_요청("2호선", "green", 0);
 
         // when
         ExtractableResponse<Response> response = RestAssured

--- a/src/test/java/nextstep/subway/acceptance/LineSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/LineSteps.java
@@ -9,10 +9,11 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class LineSteps {
-    public static ExtractableResponse<Response> 지하철_노선_생성_요청(String name, String color) {
+    public static ExtractableResponse<Response> 지하철_노선_생성_요청(String name, String color, int surcharge) {
         Map<String, String> params = new HashMap<>();
         params.put("name", name);
         params.put("color", color);
+        params.put("surcharge", surcharge + "");
         return RestAssured
                 .given().log().all()
                 .body(params)

--- a/src/test/java/nextstep/subway/acceptance/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/MemberAcceptanceTest.java
@@ -12,11 +12,11 @@ import static nextstep.subway.acceptance.MemberSteps.회원_생성_요청;
 import static nextstep.subway.acceptance.MemberSteps.회원_정보_수정_요청;
 import static nextstep.subway.acceptance.MemberSteps.회원_정보_조회_요청;
 import static nextstep.subway.acceptance.MemberSteps.회원_정보_조회됨;
+import static nextstep.subway.utils.Users.성인;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class MemberAcceptanceTest extends AcceptanceTest {
-    public static final String EMAIL = "email@email.com";
-    public static final String ADMIN = "admin@email.com";
+    public static final String EMAIL = "email123123@email.com";
     public static final String PASSWORD = "password";
     public static final int AGE = 20;
 
@@ -73,10 +73,11 @@ class MemberAcceptanceTest extends AcceptanceTest {
     @DisplayName("내 정보를 조회한다.")
     @Test
     void getMyInfo() {
-        String accessToken = 베어러_인증_로그인_요청(ADMIN, PASSWORD).jsonPath().getString("accessToken");
+        // DataLoader로 적재해둔 값으로 테스트
+        String accessToken = 베어러_인증_로그인_요청(성인.getEmail(), 성인.getPassword()).jsonPath().getString("accessToken");
 
         ExtractableResponse<Response> response = 회원_정보_조회_요청(accessToken);
 
-        회원_정보_조회됨(response, ADMIN, AGE);
+        회원_정보_조회됨(response, 성인.getEmail(), 성인.getAge());
     }
 }

--- a/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
@@ -99,7 +99,7 @@ class PathAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(남부터미널역, 교대역, 강남역),
                 () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(12),
                 () -> assertThat(response.jsonPath().getInt("duration")).isEqualTo(12),
-                () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(1_450 + 900)
+                () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(1_250 + 100 + 900)
         );
     }
 

--- a/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
@@ -15,7 +15,6 @@ import static nextstep.subway.acceptance.LineSteps.지하철_노선에_지하철
 import static nextstep.subway.acceptance.MemberSteps.베어러_인증_로그인_요청;
 import static nextstep.subway.acceptance.PathSteps.경로_조회_요청;
 import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 

--- a/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
@@ -64,7 +64,7 @@ class PathAcceptanceTest extends AcceptanceTest {
         청소년 = 베어러_인증_로그인_요청(Users.청소년.getEmail(), Users.청소년.getPassword()).jsonPath().getString("accessToken");
         어린이 = 베어러_인증_로그인_요청(Users.어린이.getEmail(), Users.어린이.getPassword()).jsonPath().getString("accessToken");
     }
-    
+
     /**
      * Feature: 지하철 경로 검색
      *

--- a/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
@@ -3,6 +3,7 @@ package nextstep.subway.acceptance;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.domain.SearchType;
+import nextstep.subway.utils.Users;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -11,13 +12,16 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static nextstep.subway.acceptance.LineSteps.지하철_노선에_지하철_구간_생성_요청;
+import static nextstep.subway.acceptance.MemberSteps.베어러_인증_로그인_요청;
 import static nextstep.subway.acceptance.PathSteps.경로_조회_요청;
 import static nextstep.subway.acceptance.StationSteps.지하철역_생성_요청;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 @DisplayName("지하철 경로 검색")
 class PathAcceptanceTest extends AcceptanceTest {
+
     private Long 교대역;
     private Long 강남역;
     private Long 양재역;
@@ -25,6 +29,9 @@ class PathAcceptanceTest extends AcceptanceTest {
     private Long 이호선;
     private Long 신분당선;
     private Long 삼호선;
+    private String 성인;
+    private String 청소년;
+    private String 어린이;
 
     /**
      * Given 지하철역이 등록되어있음
@@ -52,9 +59,12 @@ class PathAcceptanceTest extends AcceptanceTest {
         삼호선 = 지하철_노선_생성_요청("3호선", "orange", 900,교대역, 남부터미널역, 2, 2);
 
         지하철_노선에_지하철_구간_생성_요청(삼호선, createSectionCreateParams(남부터미널역, 양재역, 3, 3));
+
+        성인 = 베어러_인증_로그인_요청(Users.성인.getEmail(), Users.성인.getPassword()).jsonPath().getString("accessToken");
+        청소년 = 베어러_인증_로그인_요청(Users.청소년.getEmail(), Users.청소년.getPassword()).jsonPath().getString("accessToken");
+        어린이 = 베어러_인증_로그인_요청(Users.어린이.getEmail(), Users.어린이.getPassword()).jsonPath().getString("accessToken");
     }
-
-
+    
     /**
      * Feature: 지하철 경로 검색
      *
@@ -100,6 +110,78 @@ class PathAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(12),
                 () -> assertThat(response.jsonPath().getInt("duration")).isEqualTo(12),
                 () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(1_250 + 100 + 900)
+        );
+    }
+
+    /**
+     * Feature: 연령별 요금 정책
+     *
+     *   Scenario: 로그인 사용자는 연령별 요금으로 계산
+     *     When 출발역에서 도착역까지의 최단 거리 경로 조회를 요청
+     *     Then 최단 거리 경로를 응답
+     *     And 총 거리와 소요 시간을 함께 응답함
+     *     And 지하철 이용 요금도 함께 응답함
+     */
+    @DisplayName("어린이와 청소년이 아닌경우 운임의 변화는 없다.")
+    @Test
+    void fareByAge() {
+        // when
+        ExtractableResponse<Response> response = 경로_조회_요청(성인, 남부터미널역, 강남역, SearchType.DISTANCE.name());
+
+        // then
+        assertAll(
+                () -> assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(남부터미널역, 교대역, 강남역),
+                () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(12),
+                () -> assertThat(response.jsonPath().getInt("duration")).isEqualTo(12),
+                () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo(1_250 + 100 + 900)
+        );
+    }
+
+    /**
+     * Feature: 연령별 요금 정책
+     *
+     *   Scenario: 로그인 사용자는 연령별 요금으로 계산
+     *     When 출발역에서 도착역까지의 최단 거리 경로 조회를 요청
+     *     Then 최단 거리 경로를 응답
+     *     And 총 거리와 소요 시간을 함께 응답함
+     *     And 지하철 이용 요금도 함께 응답함
+     */
+    @DisplayName("청소년은 운임에서 20%를 할인한다.")
+    @Test
+    void fareWhenChildren() {
+        // when
+        ExtractableResponse<Response> response = 경로_조회_요청(청소년, 남부터미널역, 강남역, SearchType.DISTANCE.name());
+
+        // then
+        assertAll(
+                () -> assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(남부터미널역, 교대역, 강남역),
+                () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(12),
+                () -> assertThat(response.jsonPath().getInt("duration")).isEqualTo(12),
+                () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo((1_250 + 100 + 900) * 0.8)
+        );
+    }
+
+    /**
+     * Feature: 연령별 요금 정책
+     *
+     *   Scenario: 로그인 사용자는 연령별 요금으로 계산
+     *     When 출발역에서 도착역까지의 최단 거리 경로 조회를 요청
+     *     Then 최단 거리 경로를 응답
+     *     And 총 거리와 소요 시간을 함께 응답함
+     *     And 지하철 이용 요금도 함께 응답함
+     */
+    @DisplayName("어린이는 운임에서 50%를 할인한다.")
+    @Test
+    void fareWhenTeenager() {
+        // when
+        ExtractableResponse<Response> response = 경로_조회_요청(어린이, 남부터미널역, 강남역, SearchType.DISTANCE.name());
+
+        // then
+        assertAll(
+                () -> assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(남부터미널역, 교대역, 강남역),
+                () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(12),
+                () -> assertThat(response.jsonPath().getInt("duration")).isEqualTo(12),
+                () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo((1_250 + 100 + 900) * 0.5)
         );
     }
 

--- a/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/acceptance/PathAcceptanceTest.java
@@ -156,7 +156,7 @@ class PathAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(남부터미널역, 교대역, 강남역),
                 () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(12),
                 () -> assertThat(response.jsonPath().getInt("duration")).isEqualTo(12),
-                () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo((1_250 + 100 + 900) * 0.8)
+                () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo((int) ((1_250 + 100 + 900) * 0.8))
         );
     }
 
@@ -180,7 +180,7 @@ class PathAcceptanceTest extends AcceptanceTest {
                 () -> assertThat(response.jsonPath().getList("stations.id", Long.class)).containsExactly(남부터미널역, 교대역, 강남역),
                 () -> assertThat(response.jsonPath().getInt("distance")).isEqualTo(12),
                 () -> assertThat(response.jsonPath().getInt("duration")).isEqualTo(12),
-                () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo((1_250 + 100 + 900) * 0.5)
+                () -> assertThat(response.jsonPath().getInt("fare")).isEqualTo((int) ((1_250 + 100 + 900) * 0.5))
         );
     }
 

--- a/src/test/java/nextstep/subway/acceptance/PathSteps.java
+++ b/src/test/java/nextstep/subway/acceptance/PathSteps.java
@@ -20,6 +20,19 @@ public class PathSteps {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 경로_조회_요청(String accessToken, Long source, Long target, String type) {
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(accessToken)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .queryParam("source", source)
+                .queryParam("target", target)
+                .queryParam("type", type)
+                .when().get("/paths")
+                .then().log().all()
+                .extract();
+    }
+
     public static ExtractableResponse<Response> 경로_조회_요청(Long source, Long target, String type, RequestSpecification requestSpecification) {
         return requestSpecification
                 .accept(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/nextstep/subway/documentation/Documentation.java
+++ b/src/test/java/nextstep/subway/documentation/Documentation.java
@@ -9,12 +9,14 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.headers.HeaderDescriptor;
 import org.springframework.restdocs.payload.FieldDescriptor;
 import org.springframework.restdocs.request.ParameterDescriptor;
 import org.springframework.test.context.ActiveProfiles;
 
 import java.util.List;
 
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
@@ -45,7 +47,7 @@ public class Documentation {
                 .build();
     }
 
-    protected RequestSpecification documentConfig(String documentIdentifier, List<ParameterDescriptor> parameterDescriptors, List<FieldDescriptor> fieldDescriptors) {
+    protected RequestSpecification documentConfig(String documentIdentifier, List<HeaderDescriptor> headerDescriptors, List<ParameterDescriptor> parameterDescriptors, List<FieldDescriptor> fieldDescriptors) {
         return RestAssured
                 .given(spec).log().all()
                 .filter(
@@ -53,6 +55,7 @@ public class Documentation {
                                 documentIdentifier,
                                 preprocessRequest(prettyPrint()),
                                 preprocessResponse(prettyPrint()),
+                                requestHeaders(headerDescriptors),
                                 requestParameters(parameterDescriptors),
                                 responseFields(fieldDescriptors)
                         )

--- a/src/test/java/nextstep/subway/documentation/Documentation.java
+++ b/src/test/java/nextstep/subway/documentation/Documentation.java
@@ -9,9 +9,18 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.payload.FieldDescriptor;
+import org.springframework.restdocs.request.ParameterDescriptor;
 import org.springframework.test.context.ActiveProfiles;
 
+import java.util.List;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
 import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
+import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.documentationConfiguration;
 
 @ActiveProfiles("test")
@@ -34,5 +43,19 @@ public class Documentation {
                         .withRequestDefaults(prettyPrint())
                         .withResponseDefaults(prettyPrint()))
                 .build();
+    }
+
+    protected RequestSpecification documentConfig(String documentIdentifier, List<ParameterDescriptor> parameterDescriptors, List<FieldDescriptor> fieldDescriptors) {
+        return RestAssured
+                .given(spec).log().all()
+                .filter(
+                        document(
+                                documentIdentifier,
+                                preprocessRequest(prettyPrint()),
+                                preprocessResponse(prettyPrint()),
+                                requestParameters(parameterDescriptors),
+                                responseFields(fieldDescriptors)
+                        )
+                );
     }
 }

--- a/src/test/java/nextstep/subway/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/documentation/PathDocumentation.java
@@ -3,18 +3,13 @@ package nextstep.subway.documentation;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
-import nextstep.member.application.MemberService;
-import nextstep.member.domain.AnonymousUser;
-import nextstep.member.domain.LoginMember;
+import nextstep.member.domain.AuthenticatedUser;
 import nextstep.subway.applicaion.PathService;
 import nextstep.subway.applicaion.dto.PathResponse;
 import nextstep.subway.applicaion.dto.StationResponse;
 import nextstep.subway.domain.SearchType;
-import nextstep.subway.utils.Users;
 import org.assertj.core.util.Lists;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.mockito.ArgumentMatcher;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.payload.JsonFieldType;
@@ -25,20 +20,16 @@ import static nextstep.subway.acceptance.PathSteps.경로_조회_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.when;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 
-@Disabled
 public class PathDocumentation extends Documentation {
     public static final long SOURCE_ID = 1L;
     public static final long TARGET_ID = 2L;
     @MockBean
     private PathService pathService;
-    @MockBean
-    private MemberService memberService;
 
     @Test
     void path() {
@@ -47,32 +38,12 @@ public class PathDocumentation extends Documentation {
                 Lists.newArrayList(
                         new StationResponse(SOURCE_ID, "강남역"),
                         new StationResponse(TARGET_ID, "역삼역")
-                ), 10, 10, 1_250);
-        when(pathService.findPath(any(AnonymousUser.class), anyLong(), anyLong(), any(SearchType.class))).thenReturn(pathResponse);
-
-        PathResponse pathResponseOf어린이사용자 = new PathResponse(
-                Lists.newArrayList(
-                        new StationResponse(SOURCE_ID, "강남역"),
-                        new StationResponse(TARGET_ID, "역삼역")
-                ), 10, 10, (int) (1_250 * 0.5));
-        when(pathService.findPath(argThat((ArgumentMatcher<LoginMember>) loginMember -> {
-            when(memberService.findMember(loginMember.getId()).getAge()).thenReturn(Users.어린이.getAge());
-
-            int age = memberService.findMember(loginMember.getId()).getAge();
-            return 6 <= age && age < 13;
-        }), anyLong(), anyLong(), any(SearchType.class))).thenReturn(pathResponseOf어린이사용자);
-
-        PathResponse pathResponseOf청소년사용자 = new PathResponse(
-                Lists.newArrayList(
-                        new StationResponse(SOURCE_ID, "강남역"),
-                        new StationResponse(TARGET_ID, "역삼역")
-                ), 10, 10, (int) (1_250 * 0.8));
-        when(pathService.findPath(argThat((ArgumentMatcher<LoginMember>) loginMember -> {
-            when(memberService.findMember(loginMember.getId()).getAge()).thenReturn(Users.청소년.getAge());
-
-            int age = memberService.findMember(loginMember.getId()).getAge();
-            return 13 <= age && age < 19;
-        }), anyLong(), anyLong(), any(SearchType.class))).thenReturn(pathResponseOf청소년사용자);
+                ),
+                10,
+                10,
+                1_250
+        );
+        when(pathService.findPath(any(AuthenticatedUser.class), anyLong(), anyLong(), any(SearchType.class))).thenReturn(pathResponse);
 
         RequestSpecification requestSpecification = documentConfig(
                 "path",

--- a/src/test/java/nextstep/subway/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/documentation/PathDocumentation.java
@@ -12,6 +12,7 @@ import nextstep.subway.applicaion.dto.StationResponse;
 import nextstep.subway.domain.SearchType;
 import nextstep.subway.utils.Users;
 import org.assertj.core.util.Lists;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatcher;
 import org.springframework.boot.test.mock.mockito.MockBean;
@@ -30,6 +31,7 @@ import static org.springframework.restdocs.headers.HeaderDocumentation.headerWit
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 
+@Disabled
 public class PathDocumentation extends Documentation {
     public static final long SOURCE_ID = 1L;
     public static final long TARGET_ID = 2L;

--- a/src/test/java/nextstep/subway/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/documentation/PathDocumentation.java
@@ -1,6 +1,5 @@
 package nextstep.subway.documentation;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import io.restassured.specification.RequestSpecification;
@@ -14,19 +13,15 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.HttpStatus;
 import org.springframework.restdocs.payload.JsonFieldType;
 
+import java.util.List;
+
 import static nextstep.subway.acceptance.PathSteps.경로_조회_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse;
-import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
-import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.requestParameters;
-import static org.springframework.restdocs.restassured3.RestAssuredRestDocumentation.document;
 
 public class PathDocumentation extends Documentation {
     public static final long SOURCE_ID = 1L;
@@ -44,30 +39,23 @@ public class PathDocumentation extends Documentation {
                 ), 10, 10, 1_250);
         when(pathService.findPath(anyLong(), anyLong(), any(SearchType.class))).thenReturn(pathResponse);
 
+        RequestSpecification requestSpecification = documentConfig(
+                "path",
+                List.of(parameterWithName("source").description("출발역 id"),
+                        parameterWithName("target").description("도착역 id"),
+                        parameterWithName("type").description("경로 조회 조건")),
+                List.of(fieldWithPath("stations").type(JsonFieldType.ARRAY).description("경로의 지하철 역 목록"),
+                        fieldWithPath("stations[].id").type(JsonFieldType.NUMBER).description("지하철 역 id"),
+                        fieldWithPath("stations[].name").type(JsonFieldType.STRING).description("지하철 역 이름"),
+                        fieldWithPath("distance").type(JsonFieldType.NUMBER).description("경로의 이동거리"),
+                        fieldWithPath("duration").type(JsonFieldType.NUMBER).description("경로의 이동시간"),
+                        fieldWithPath("fare").type(JsonFieldType.NUMBER).description("지하철 이용요금"))
+        );
+
         // When
-        ExtractableResponse<Response> response = 경로_조회_요청(SOURCE_ID, TARGET_ID, SearchType.DURATION.name(), documentConfig("path"));
+        ExtractableResponse<Response> response = 경로_조회_요청(SOURCE_ID, TARGET_ID, SearchType.DURATION.name(), requestSpecification);
 
         // Then
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    private RequestSpecification documentConfig(String documentIdentifier) {
-        return RestAssured
-                .given(spec).log().all()
-                .filter(document(documentIdentifier, preprocessRequest(prettyPrint()), preprocessResponse(prettyPrint()),
-                        requestParameters(
-                                parameterWithName("source").description("출발역 id"),
-                                parameterWithName("target").description("도착역 id"),
-                                parameterWithName("type").description("경로 조회 조건")
-                        ),
-                        responseFields(
-                                fieldWithPath("stations").type(JsonFieldType.ARRAY).description("경로의 지하철 역 목록"),
-                                fieldWithPath("stations[].id").type(JsonFieldType.NUMBER).description("지하철 역 id"),
-                                fieldWithPath("stations[].name").type(JsonFieldType.STRING).description("지하철 역 이름"),
-                                fieldWithPath("distance").type(JsonFieldType.NUMBER).description("경로의 이동거리"),
-                                fieldWithPath("duration").type(JsonFieldType.NUMBER).description("경로의 이동시간"),
-                                fieldWithPath("fare").type(JsonFieldType.NUMBER).description("지하철 이용요금")
-                        )
-                ));
     }
 }

--- a/src/test/java/nextstep/subway/documentation/PathDocumentation.java
+++ b/src/test/java/nextstep/subway/documentation/PathDocumentation.java
@@ -20,6 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
 import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
 
@@ -41,6 +42,7 @@ public class PathDocumentation extends Documentation {
 
         RequestSpecification requestSpecification = documentConfig(
                 "path",
+                List.of(headerWithName("Authorization").description("인증 토큰").optional()),
                 List.of(parameterWithName("source").description("출발역 id"),
                         parameterWithName("target").description("도착역 id"),
                         parameterWithName("type").description("경로 조회 조건")),

--- a/src/test/java/nextstep/subway/unit/AgeFarePolicyTest.java
+++ b/src/test/java/nextstep/subway/unit/AgeFarePolicyTest.java
@@ -1,0 +1,32 @@
+package nextstep.subway.unit;
+
+import nextstep.subway.domain.AgeFarePolicy;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AgeFarePolicyTest {
+
+    /**
+     * 어린이: 6세 이상~ 13세 미만   ; 50% 할인
+     * 청소년: 13세 이상 ~ 19세 미만 ; 20% 할인
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "1_000, 5, 1_000",
+            "1_000, 6, 500",
+            "1_000, 7, 500",
+
+            "1_000, 12, 500",
+            "1_000, 13, 800",
+            "1_000, 13, 800",
+
+            "1_000, 18, 800",
+            "1_000, 19, 1_000",
+            "1_000, 20, 1_000",
+    })
+    void calculateTotalFare(int fare, int age, int discountedFare) {
+        assertThat(AgeFarePolicy.calculate(fare, age)).isEqualTo(discountedFare);
+    }
+}

--- a/src/test/java/nextstep/subway/unit/AuthenticationPrincipalArgumentResolverTest.java
+++ b/src/test/java/nextstep/subway/unit/AuthenticationPrincipalArgumentResolverTest.java
@@ -1,0 +1,131 @@
+package nextstep.subway.unit;
+
+import nextstep.member.application.JwtTokenProvider;
+import nextstep.member.domain.AnonymousUser;
+import nextstep.member.domain.AuthenticatedUser;
+import nextstep.member.domain.LoginMember;
+import nextstep.member.domain.Member;
+import nextstep.member.domain.MemberRepository;
+import nextstep.member.domain.RoleType;
+import nextstep.member.ui.AuthenticationPrincipalArgumentResolver;
+import nextstep.subway.domain.SearchType;
+import nextstep.subway.ui.PathController;
+import nextstep.subway.utils.Users;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.core.MethodParameter;
+import org.springframework.web.context.request.NativeWebRequest;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+
+import static nextstep.subway.utils.Users.성인;
+import static nextstep.subway.utils.Users.어린이;
+import static nextstep.subway.utils.Users.청소년;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+@DataJpaTest
+public class AuthenticationPrincipalArgumentResolverTest {
+
+    private AuthenticationPrincipalArgumentResolver authenticationPrincipalArgumentResolver;
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    private MethodParameter parameter;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Mock
+    private NativeWebRequest webRequest;
+
+    private String tokenOf성인사용자;
+    private String tokenOf청소년사용자;
+    private String tokenOf어린이사용자;
+
+    @BeforeEach
+    void setUp() throws NoSuchFieldException, IllegalAccessException, NoSuchMethodException {
+        // JWT provider 필드값 주입 (리플렉션 활용)
+        jwtTokenProvider = new JwtTokenProvider();
+
+        Field secretKey = JwtTokenProvider.class.getDeclaredField("secretKey");
+        secretKey.setAccessible(true);
+        secretKey.set(jwtTokenProvider, "atdd-secret-key");
+
+        Field validityInMilliseconds = JwtTokenProvider.class.getDeclaredField("validityInMilliseconds");
+        validityInMilliseconds.setAccessible(true);
+        validityInMilliseconds.set(jwtTokenProvider, 3600000);
+
+        // authenticationPrincipalArgumentResolver 객체 할당
+        authenticationPrincipalArgumentResolver = new AuthenticationPrincipalArgumentResolver(jwtTokenProvider);
+
+        // resolveArgument 메서드의 MethodParameter 할당 (AuthenticationPrincipal 어노테이션이 붙은 첫번째 인자만 테스트한다.)
+        parameter = new MethodParameter(PathController.class.getDeclaredMethod("findPath", AuthenticatedUser.class, Long.class, Long.class, SearchType.class), 0);
+
+        // 사용자 authentication
+        memberRepository.save(new Member(성인.getEmail(), 성인.getPassword(), 성인.getAge(), Arrays.asList(RoleType.ROLE_MEMBER.name())));
+        memberRepository.save(new Member(청소년.getEmail(), 청소년.getPassword(), 청소년.getAge(), Arrays.asList(RoleType.ROLE_MEMBER.name())));
+        memberRepository.save(new Member(어린이.getEmail(), 어린이.getPassword(), 어린이.getAge(), Arrays.asList(RoleType.ROLE_MEMBER.name())));
+
+        Member 성인사용자 = memberRepository.findByEmail(Users.성인.getEmail()).get();
+        Member 청소년사용자 = memberRepository.findByEmail(Users.청소년.getEmail()).get();
+        Member 어린이사용자 = memberRepository.findByEmail(Users.어린이.getEmail()).get();
+
+        tokenOf성인사용자 = jwtTokenProvider.createToken(성인사용자.getId().toString(), Arrays.asList(RoleType.ROLE_MEMBER.name()));
+        tokenOf청소년사용자 = jwtTokenProvider.createToken(청소년사용자.getId().toString(), Arrays.asList(RoleType.ROLE_MEMBER.name()));
+        tokenOf어린이사용자 = jwtTokenProvider.createToken(어린이사용자.getId().toString(), Arrays.asList(RoleType.ROLE_MEMBER.name()));
+    }
+
+    @Test
+    void 성인사용자() throws Exception {
+        when(webRequest.getHeader("Authorization")).thenReturn(createAuthorizationHeader(tokenOf성인사용자));
+
+        LoginMember 성인 = (LoginMember) authenticationPrincipalArgumentResolver.resolveArgument(parameter, null, webRequest, null);
+
+        Long id = Long.parseLong(jwtTokenProvider.getPrincipal(tokenOf성인사용자));
+        LoginMember loginMember = new LoginMember(id, Arrays.asList(RoleType.ROLE_MEMBER.name()));
+        assertThat(성인).isEqualTo(loginMember);
+    }
+
+    private String createAuthorizationHeader(String token) {
+        return String.format("bearer %s", token);
+    }
+
+    @Test
+    void 청소년사용자() throws Exception {
+        when(webRequest.getHeader("Authorization")).thenReturn(createAuthorizationHeader(tokenOf청소년사용자));
+
+        LoginMember 청소년 = (LoginMember) authenticationPrincipalArgumentResolver.resolveArgument(parameter, null, webRequest, null);
+
+        Long id = Long.parseLong(jwtTokenProvider.getPrincipal(tokenOf청소년사용자));
+        LoginMember loginMember = new LoginMember(id, Arrays.asList(RoleType.ROLE_MEMBER.name()));
+        assertThat(청소년).isEqualTo(loginMember);
+    }
+
+    @Test
+    void 어린이사용자() throws Exception {
+        when(webRequest.getHeader("Authorization")).thenReturn(createAuthorizationHeader(tokenOf어린이사용자));
+
+        LoginMember 어린이 = (LoginMember) authenticationPrincipalArgumentResolver.resolveArgument(parameter, null, webRequest, null);
+
+        Long id = Long.parseLong(jwtTokenProvider.getPrincipal(tokenOf어린이사용자));
+        LoginMember loginMember = new LoginMember(id, Arrays.asList(RoleType.ROLE_MEMBER.name()));
+        assertThat(어린이).isEqualTo(loginMember);
+    }
+
+    @Test
+    void 익명사용자() throws Exception {
+        when(webRequest.getHeader("Authorization")).thenReturn(null);
+
+        AnonymousUser 익명사용자 = (AnonymousUser) authenticationPrincipalArgumentResolver.resolveArgument(parameter, null, webRequest, null);
+
+        assertThat(익명사용자).isInstanceOf(AnonymousUser.class);
+    }
+}

--- a/src/test/java/nextstep/subway/unit/DistanceFarePolicyTest.java
+++ b/src/test/java/nextstep/subway/unit/DistanceFarePolicyTest.java
@@ -1,6 +1,6 @@
 package nextstep.subway.unit;
 
-import nextstep.subway.domain.FarePolicy;
+import nextstep.subway.domain.DistanceFarePolicy;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -9,7 +9,7 @@ import java.lang.reflect.Method;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-public class FarePolicyTest {
+public class DistanceFarePolicyTest {
 
     @ParameterizedTest
     @CsvSource({
@@ -22,7 +22,7 @@ public class FarePolicyTest {
             "51,2_150",
     })
     void calculateTotalFare(int distance, int fare) {
-        assertThat(FarePolicy.calculate(distance)).isEqualTo(fare);
+        assertThat(DistanceFarePolicy.calculate(distance)).isEqualTo(fare);
     }
 
     /**
@@ -46,7 +46,7 @@ public class FarePolicyTest {
             "50,59,8, 200",
     })
     void calculateExtraFare(int start, int end, int unit, int expected) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
-        Method method = FarePolicy.class.getDeclaredMethod("calculateExtraFare", int.class, int.class, int.class);
+        Method method = DistanceFarePolicy.class.getDeclaredMethod("calculateExtraFare", int.class, int.class, int.class);
         method.setAccessible(true);
 
         int result = (int) method.invoke(null,start, end, unit);

--- a/src/test/java/nextstep/subway/unit/FareCalculatorTest.java
+++ b/src/test/java/nextstep/subway/unit/FareCalculatorTest.java
@@ -4,7 +4,7 @@ import nextstep.member.domain.AnonymousUser;
 import nextstep.member.domain.LoginMember;
 import nextstep.member.domain.Member;
 import nextstep.member.domain.MemberRepository;
-import nextstep.subway.applicaion.FareService;
+import nextstep.subway.applicaion.FareCalculator;
 import nextstep.subway.domain.Line;
 import nextstep.subway.domain.Path;
 import nextstep.subway.domain.Section;
@@ -21,12 +21,12 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
 @ActiveProfiles("test")
-class FareServiceTest {
+@SpringBootTest
+class FareCalculatorTest {
 
-    @Autowired
-    private FareService fareService;
+    private FareCalculator fareCalculator = new FareCalculator();
+
     @Autowired
     private MemberRepository memberRepository;
 
@@ -71,28 +71,28 @@ class FareServiceTest {
 
     @Test
     void getTotalFareOf어린이사용자() {
-        int totalFare = fareService.getTotalFare(어린이사용자, path);
+        int totalFare = fareCalculator.getTotalFare(어린이사용자, path);
 
         assertThat(totalFare).isEqualTo((int) ((1_250 + 200 + 900) * 0.5));
     }
 
     @Test
     void getTotalFareOf청소년사용자() {
-        int totalFare = fareService.getTotalFare(청소년사용자, path);
+        int totalFare = fareCalculator.getTotalFare(청소년사용자, path);
 
         assertThat(totalFare).isEqualTo((int) ((1_250 + 200 + 900) * 0.8));
     }
 
     @Test
     void getTotalFareOf성인사용자() {
-        int totalFare = fareService.getTotalFare(성인사용자, path);
+        int totalFare = fareCalculator.getTotalFare(성인사용자, path);
 
         assertThat(totalFare).isEqualTo(1_250 + 200 + 900);
     }
 
     @Test
     void getTotalFareOf익명사용자() {
-        int totalFare = fareService.getTotalFare(익명사용자, path);
+        int totalFare = fareCalculator.getTotalFare(익명사용자, path);
 
         assertThat(totalFare).isEqualTo(1_250 + 200 + 900);
     }

--- a/src/test/java/nextstep/subway/unit/FarePolicyTest.java
+++ b/src/test/java/nextstep/subway/unit/FarePolicyTest.java
@@ -4,6 +4,9 @@ import nextstep.subway.domain.FarePolicy;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class FarePolicyTest {
@@ -18,7 +21,36 @@ public class FarePolicyTest {
             "50,2_050",
             "51,2_150",
     })
-    void calculate(int distance, int fare) {
+    void calculateTotalFare(int distance, int fare) {
         assertThat(FarePolicy.calculate(distance)).isEqualTo(fare);
+    }
+
+    /**
+     * calculateExtraFare() 메서드의 문서화를 위한 테스트 코드 작성
+     *
+     * 추가 운임에 대한 거리에 따른 계산 메서드
+     *
+     * @param start 시작 위치
+     * @param end   도착 위치
+     * @param unit  추가 운임의 단위거리
+     * @return 거리에 따른 추가운임
+     */
+    @ParameterizedTest
+    @CsvSource({
+            "10,14,5, 100",
+            "10,15,5, 100",
+            "10,16,5, 200",
+
+            "50,57,8, 100",
+            "50,58,8, 100",
+            "50,59,8, 200",
+    })
+    void calculateExtraFare(int start, int end, int unit, int expected) throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+        Method method = FarePolicy.class.getDeclaredMethod("calculateExtraFare", int.class, int.class, int.class);
+        method.setAccessible(true);
+
+        int result = (int) method.invoke(null,start, end, unit);
+
+        assertThat(result).isEqualTo(expected);
     }
 }

--- a/src/test/java/nextstep/subway/unit/FareServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/FareServiceTest.java
@@ -44,9 +44,9 @@ class FareServiceTest {
         Member 청소년 = memberRepository.findByEmail(Users.청소년.getEmail()).get();
         Member 성인 = memberRepository.findByEmail(Users.성인.getEmail()).get();
 
-        어린이사용자 = new LoginMember(어린이.getId(), 어린이.getRoles());
-        청소년사용자 = new LoginMember(청소년.getId(), 청소년.getRoles());
-        성인사용자 = new LoginMember(성인.getId(), 성인.getRoles());
+        어린이사용자 = new LoginMember(어린이.getId(), 어린이.getAge(), 어린이.getRoles());
+        청소년사용자 = new LoginMember(청소년.getId(), 청소년.getAge(), 청소년.getRoles());
+        성인사용자 = new LoginMember(성인.getId(), 성인.getAge(), 성인.getRoles());
         익명사용자 = new AnonymousUser();
 
         // path

--- a/src/test/java/nextstep/subway/unit/FareServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/FareServiceTest.java
@@ -1,0 +1,99 @@
+package nextstep.subway.unit;
+
+import nextstep.member.domain.AnonymousUser;
+import nextstep.member.domain.LoginMember;
+import nextstep.member.domain.Member;
+import nextstep.member.domain.MemberRepository;
+import nextstep.subway.applicaion.FareService;
+import nextstep.subway.domain.Line;
+import nextstep.subway.domain.Path;
+import nextstep.subway.domain.Section;
+import nextstep.subway.domain.Sections;
+import nextstep.subway.domain.Station;
+import nextstep.subway.utils.Users;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@ActiveProfiles("test")
+class FareServiceTest {
+
+    @Autowired
+    private FareService fareService;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    private AnonymousUser 익명사용자;
+    private LoginMember 어린이사용자;
+    private LoginMember 청소년사용자;
+    private LoginMember 성인사용자;
+
+    private Path path;
+
+    @BeforeEach
+    void setUp() {
+        // 사용자
+        Member 어린이 = memberRepository.findByEmail(Users.어린이.getEmail()).get();
+        Member 청소년 = memberRepository.findByEmail(Users.청소년.getEmail()).get();
+        Member 성인 = memberRepository.findByEmail(Users.성인.getEmail()).get();
+
+        어린이사용자 = new LoginMember(어린이.getId(), 어린이.getRoles());
+        청소년사용자 = new LoginMember(청소년.getId(), 청소년.getRoles());
+        성인사용자 = new LoginMember(성인.getId(), 성인.getRoles());
+        익명사용자 = new AnonymousUser();
+
+        // path
+        Station 강남역 = new Station("강남역");
+        Station 역삼역 = new Station("역삼역");
+        Station 선릉역 = new Station("선릉역");
+        Station 삼성역 = new Station("삼성역");
+
+        Line 이호선 = new Line("2호선", "green", 0);
+        Line 삼호선 = new Line("3호선", "orange", 500);
+        Line 신분당선 = new Line("신분당선", "red", 900);
+
+        Sections sections = new Sections(
+                List.of(
+                        new Section(이호선, 강남역, 역삼역, 10, 10),
+                        new Section(삼호선, 역삼역, 선릉역, 2, 2),
+                        new Section(신분당선, 선릉역, 삼성역, 4, 4)
+                )
+        );
+        path = new Path(sections);
+    }
+
+    @Test
+    void getTotalFareOf어린이사용자() {
+        int totalFare = fareService.getTotalFare(어린이사용자, path);
+
+        assertThat(totalFare).isEqualTo((int) ((1_250 + 200 + 900) * 0.5));
+    }
+
+    @Test
+    void getTotalFareOf청소년사용자() {
+        int totalFare = fareService.getTotalFare(청소년사용자, path);
+
+        assertThat(totalFare).isEqualTo((int) ((1_250 + 200 + 900) * 0.8));
+    }
+
+    @Test
+    void getTotalFareOf성인사용자() {
+        int totalFare = fareService.getTotalFare(성인사용자, path);
+
+        assertThat(totalFare).isEqualTo(1_250 + 200 + 900);
+    }
+
+    @Test
+    void getTotalFareOf익명사용자() {
+        int totalFare = fareService.getTotalFare(익명사용자, path);
+
+        assertThat(totalFare).isEqualTo(1_250 + 200 + 900);
+    }
+}

--- a/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceMockTest.java
@@ -43,7 +43,7 @@ class LineServiceMockTest {
         ReflectionTestUtils.setField(역삼역, "id", 2L);
         삼성역 = new Station("삼성역");
         ReflectionTestUtils.setField(삼성역, "id", 3L);
-        이호선 = new Line("2호선", "green");
+        이호선 = new Line("2호선", "green", 0);
         이호선.addSection(강남역, 역삼역, 10, 10);
         ReflectionTestUtils.setField(이호선, "id", 1L);
     }

--- a/src/test/java/nextstep/subway/unit/LineServiceTest.java
+++ b/src/test/java/nextstep/subway/unit/LineServiceTest.java
@@ -41,7 +41,7 @@ class LineServiceTest {
     }
 
     private Line createLine(Station 강남역, Station 역삼역) {
-        Line line = new Line("2호선", "green");
+        Line line = new Line("2호선", "green", 0);
         line.addSection(강남역, 역삼역, 10, 10);
         return line;
     }

--- a/src/test/java/nextstep/subway/unit/LineSurchargePolicyTest.java
+++ b/src/test/java/nextstep/subway/unit/LineSurchargePolicyTest.java
@@ -1,21 +1,19 @@
 package nextstep.subway.unit;
 
 import nextstep.subway.domain.Line;
+import nextstep.subway.domain.LineSurchargePolicy;
 import nextstep.subway.domain.Path;
 import nextstep.subway.domain.Section;
 import nextstep.subway.domain.Sections;
 import nextstep.subway.domain.Station;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
 
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.ArgumentMatchers.anyInt;
 
-class PathTest {
+class LineSurchargePolicyTest {
 
     private Station 강남역;
     private Station 역삼역;
@@ -35,24 +33,7 @@ class PathTest {
 
         이호선 = new Line("2호선", "green", 0);
         삼호선 = new Line("3호선", "orange", 500);
-        신분당선 = new Line("2호선", "red", 900);
-    }
-
-    @ParameterizedTest
-    @CsvSource({
-            "9,1_250",
-            "10,1_250",
-            "11,1_350",
-
-            "49,2_050",
-            "50,2_050",
-            "51,2_150",
-    })
-    void extraFareAboutDistance(int distance, int fare) {
-        sections = new Sections(List.of(new Section(이호선, 강남역, 역삼역, distance, anyInt())));
-        Path path = new Path(sections);
-
-        assertThat(path.extractFare()).isEqualTo(fare);
+        신분당선 = new Line("신분당선", "red", 900);
     }
 
     @Test
@@ -66,6 +47,6 @@ class PathTest {
         );
         Path path = new Path(sections);
 
-        assertThat(path.extractFare()).isEqualTo(1_250 + 신분당선.getSurcharge());
+        assertThat(LineSurchargePolicy.calculate(path)).isEqualTo(신분당선.getSurcharge());
     }
 }

--- a/src/test/java/nextstep/subway/unit/LineTest.java
+++ b/src/test/java/nextstep/subway/unit/LineTest.java
@@ -17,7 +17,7 @@ class LineTest {
         Station 강남역 = new Station("강남역");
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
-        Line line = new Line("2호선", "green");
+        Line line = new Line("2호선", "green", 0);
 
         line.addSection(강남역, 역삼역, 10, 10);
         line.addSection(역삼역, 삼성역, 5, 5);
@@ -31,7 +31,7 @@ class LineTest {
         Station 강남역 = new Station("강남역");
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
-        Line line = new Line("2호선", "green");
+        Line line = new Line("2호선", "green", 0);
 
         line.addSection(강남역, 역삼역, 10, 10);
         line.addSection(강남역, 삼성역, 5, 5);
@@ -50,7 +50,7 @@ class LineTest {
         Station 강남역 = new Station("강남역");
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
-        Line line = new Line("2호선", "green");
+        Line line = new Line("2호선", "green", 0);
 
         line.addSection(강남역, 역삼역, 10, 10);
         line.addSection(삼성역, 역삼역, 5, 5);
@@ -69,7 +69,7 @@ class LineTest {
         Station 강남역 = new Station("강남역");
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
-        Line line = new Line("2호선", "green");
+        Line line = new Line("2호선", "green", 0);
 
         line.addSection(강남역, 역삼역, 10, 10);
         line.addSection(삼성역, 강남역, 5, 5);
@@ -88,7 +88,7 @@ class LineTest {
         Station 강남역 = new Station("강남역");
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
-        Line line = new Line("2호선", "green");
+        Line line = new Line("2호선", "green", 0);
 
         line.addSection(강남역, 역삼역, 10, 10);
         line.addSection(역삼역, 삼성역, 5, 5);
@@ -106,7 +106,7 @@ class LineTest {
         Station 강남역 = new Station("강남역");
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
-        Line line = new Line("2호선", "green");
+        Line line = new Line("2호선", "green", 0);
         line.addSection(강남역, 역삼역, 10, 10);
         line.addSection(강남역, 삼성역, 5, 5);
 
@@ -120,7 +120,7 @@ class LineTest {
     void addSectionAlreadyIncluded() {
         Station 강남역 = new Station("강남역");
         Station 역삼역 = new Station("역삼역");
-        Line line = new Line("2호선", "green");
+        Line line = new Line("2호선", "green", 0);
         line.addSection(강남역, 역삼역, 10, 10);
 
         assertThatThrownBy(() -> line.addSection(강남역, 역삼역, 5, 5))
@@ -132,7 +132,7 @@ class LineTest {
         Station 강남역 = new Station("강남역");
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
-        Line line = new Line("2호선", "green");
+        Line line = new Line("2호선", "green", 0);
         line.addSection(강남역, 역삼역, 10, 10);
         line.addSection(역삼역, 삼성역, 5, 5);
 
@@ -146,7 +146,7 @@ class LineTest {
         Station 강남역 = new Station("강남역");
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
-        Line line = new Line("2호선", "green");
+        Line line = new Line("2호선", "green", 0);
         line.addSection(강남역, 역삼역, 10, 10);
         line.addSection(역삼역, 삼성역, 5, 5);
 
@@ -160,7 +160,7 @@ class LineTest {
         Station 강남역 = new Station("강남역");
         Station 역삼역 = new Station("역삼역");
         Station 삼성역 = new Station("삼성역");
-        Line line = new Line("2호선", "green");
+        Line line = new Line("2호선", "green", 0);
         line.addSection(강남역, 역삼역, 10, 10);
         line.addSection(역삼역, 삼성역, 5, 5);
 
@@ -174,7 +174,7 @@ class LineTest {
     void removeSectionNotEndOfList() {
         Station 강남역 = new Station("강남역");
         Station 역삼역 = new Station("역삼역");
-        Line line = new Line("2호선", "green");
+        Line line = new Line("2호선", "green", 0);
         line.addSection(강남역, 역삼역, 10, 10);
 
         assertThatThrownBy(() -> line.deleteSection(역삼역))

--- a/src/test/java/nextstep/subway/unit/PathTest.java
+++ b/src/test/java/nextstep/subway/unit/PathTest.java
@@ -6,6 +6,7 @@ import nextstep.subway.domain.Section;
 import nextstep.subway.domain.Sections;
 import nextstep.subway.domain.Station;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 
@@ -18,14 +19,23 @@ class PathTest {
 
     private Station 강남역;
     private Station 역삼역;
+    private Station 선릉역;
+    private Station 삼성역;
     private Line 이호선;
+    private Line 삼호선;
+    private Line 신분당선;
     private Sections sections;
 
     @BeforeEach
     void setUp() {
         강남역 = new Station("강남역");
         역삼역 = new Station("역삼역");
+        선릉역 = new Station("선릉역");
+        삼성역 = new Station("삼성역");
+
         이호선 = new Line("2호선", "green", 0);
+        삼호선 = new Line("3호선", "orange", 500);
+        신분당선 = new Line("2호선", "red", 900);
     }
 
     @ParameterizedTest
@@ -38,10 +48,24 @@ class PathTest {
             "50,2_050",
             "51,2_150",
     })
-    void extractFare(int distance, int fare) {
+    void extraFareAboutDistance(int distance, int fare) {
         sections = new Sections(List.of(new Section(이호선, 강남역, 역삼역, distance, anyInt())));
         Path path = new Path(sections);
 
         assertThat(path.extractFare()).isEqualTo(fare);
+    }
+
+    @Test
+    void extraFareAboutHighestSurchargeOfUsingLines() {
+        sections = new Sections(
+                List.of(
+                        new Section(이호선, 강남역, 역삼역, 2, 2),
+                        new Section(삼호선, 역삼역, 선릉역, 3, 3),
+                        new Section(신분당선, 선릉역, 강남역, 4, 4)
+                )
+        );
+        Path path = new Path(sections);
+
+        assertThat(path.extractFare()).isEqualTo(1_250 + 신분당선.getSurcharge());
     }
 }

--- a/src/test/java/nextstep/subway/unit/PathTest.java
+++ b/src/test/java/nextstep/subway/unit/PathTest.java
@@ -25,7 +25,7 @@ class PathTest {
     void setUp() {
         강남역 = new Station("강남역");
         역삼역 = new Station("역삼역");
-        이호선 = new Line("2호선", "green");
+        이호선 = new Line("2호선", "green", 0);
     }
 
     @ParameterizedTest

--- a/src/test/java/nextstep/subway/unit/SectionsTest.java
+++ b/src/test/java/nextstep/subway/unit/SectionsTest.java
@@ -25,7 +25,7 @@ public class SectionsTest {
         // Given
         강남역 = new Station("강남역");
         역삼역 = new Station("역삼역");
-        이호선 = new Line("2호선", "green");
+        이호선 = new Line("2호선", "green", 0);
 
         ArrayList<Section> initialSection = new ArrayList<>();
         initialSection.add(new Section(이호선, 강남역, 역삼역, 10, 10));

--- a/src/test/java/nextstep/subway/unit/SubwayMapTest.java
+++ b/src/test/java/nextstep/subway/unit/SubwayMapTest.java
@@ -33,9 +33,9 @@ public class SubwayMapTest {
         양재역 = createStation(3L, "양재역");
         남부터미널역 = createStation(4L, "남부터미널역");
 
-        신분당선 = new Line("신분당선", "red");
-        이호선 = new Line("2호선", "red");
-        삼호선 = new Line("3호선", "red");
+        이호선 = new Line("2호선", "red", 0);
+        삼호선 = new Line("3호선", "red", 500);
+        신분당선 = new Line("신분당선", "red", 900);
 
         신분당선.addSection(강남역, 양재역, 3, 3);
         이호선.addSection(교대역, 강남역, 3, 3);

--- a/src/test/java/nextstep/subway/utils/DataLoader.java
+++ b/src/test/java/nextstep/subway/utils/DataLoader.java
@@ -8,6 +8,10 @@ import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
 
+import static nextstep.subway.utils.Users.성인;
+import static nextstep.subway.utils.Users.어린이;
+import static nextstep.subway.utils.Users.청소년;
+
 @Profile("test")
 @Component
 public class DataLoader {
@@ -24,5 +28,8 @@ public class DataLoader {
         memberRepository.save(new Member(GithubResponses.사용자2.getEmail(), "password", 20, Arrays.asList(RoleType.ROLE_MEMBER.name())));
         memberRepository.save(new Member(GithubResponses.사용자3.getEmail(), "password", 20, Arrays.asList(RoleType.ROLE_MEMBER.name())));
         memberRepository.save(new Member(GithubResponses.사용자4.getEmail(), "password", 20, Arrays.asList(RoleType.ROLE_MEMBER.name())));
+        memberRepository.save(new Member(성인.getEmail(), 성인.getPassword(), 성인.getAge(), Arrays.asList(RoleType.ROLE_MEMBER.name())));
+        memberRepository.save(new Member(청소년.getEmail(), 청소년.getPassword(), 청소년.getAge(), Arrays.asList(RoleType.ROLE_MEMBER.name())));
+        memberRepository.save(new Member(어린이.getEmail(), 어린이.getPassword(), 어린이.getAge(), Arrays.asList(RoleType.ROLE_MEMBER.name())));
     }
 }

--- a/src/test/java/nextstep/subway/utils/Users.java
+++ b/src/test/java/nextstep/subway/utils/Users.java
@@ -1,0 +1,30 @@
+package nextstep.subway.utils;
+
+public enum Users {
+    성인("adult@email.com", "password", 38),
+    청소년("teenager@email.com", "password", 17),
+    어린이("children@email.com", "password", 7),
+    ;
+
+    private final String email;
+    private final String password;
+    private final int age;
+
+    Users(String email, String password, int age) {
+        this.email = email;
+        this.password = password;
+        this.age = age;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public int getAge() {
+        return age;
+    }
+}


### PR DESCRIPTION
안녕하세요 성현님!
마지막 요금 정책 추가 미션 진행했습니다

---

https://github.com/next-step/atdd-subway-fare/pull/309#pullrequestreview-1325459840
지난 미션때 코멘트 남겨주신 내용을 적용해봤습니다. 9b7abc7c02b30b0232e71c12fc5bc45601befdb1
의도하신 부분이 맞나요? 

---

스프링 시큐리티에서 익명사용자 또한 Authenticate 된 유저이더라구요
스프링 시큐리티의 context를 참고해서 간단하게 적용해봤습니다

참고링크 
- [스프링 시큐리티에서의 익명사용자](https://velog.io/@dailylifecoding/spring-security-anonymous-authentication-filter)
- [스프링 깃헙 - context 관련](https://github.com/spring-projects/spring-security/tree/main/core/src/main/java/org/springframework/security/core/context)

--- 

### 이슈

`src/main/java/nextstep/subway/applicaion/PathService.java` 의
`public PathResponse findPath(AuthenticatedUser user, Long source, Long target, SearchType searchType) {...}`

시그니처에 AuthenticatedUser타입 인자 추가 후 `src/test/java/nextstep/subway/documentation/PathDocumentation.java` 에서
테스트 실패하여 문서화 실패중입니다.
```
PathResponse pathResponseOf어린이사용자 = new PathResponse(
                Lists.newArrayList(
                        new StationResponse(SOURCE_ID, "강남역"),
                        new StationResponse(TARGET_ID, "역삼역")
                ), 10, 10, (int) (1_250 * 0.5));
        when(pathService.findPath(argThat((ArgumentMatcher<LoginMember>) loginMember -> {
            when(memberService.findMember(loginMember.getId()).getAge()).thenReturn(Users.어린이.getAge());

            int age = memberService.findMember(loginMember.getId()).getAge();
            return 6 <= age && age < 13;
        }), anyLong(), anyLong(), any(SearchType.class))).thenReturn(pathResponseOf어린이사용자);
```

실패와 별개로 궁금한 점이 있습니다. 
- 위의 코드처럼 해당 문서화 테스트 코드에서도 조건들을 검증해야할까요?
- 문서화의 다양한 예시코드를 참고할 수 있는 사이트가 있을까요?